### PR TITLE
Fix LSM9DS1 Return Values

### DIFF
--- a/devices/ST/LSM9DS1/LSM9DS1.cpp
+++ b/devices/ST/LSM9DS1/LSM9DS1.cpp
@@ -24,6 +24,9 @@ Distributed as-is; no warranty is given.
 #include "LSM9DS1.h"
 #include "LSM9DS1_Registers.h"
 #include "LSM9DS1_Types.h"
+
+#include "platform/mbed_assert.h"
+
 //#include <Wire.h> // Wire library is used for I2C
 //#include <SPI.h>  // SPI library is used for...SPI.
 
@@ -1002,6 +1005,11 @@ void LSM9DS1::mWriteByte(uint8_t subAddress, uint8_t data)
 
 uint8_t LSM9DS1::xgReadByte(uint8_t subAddress)
 {
+
+  // Assert if the driver is misconfigured
+  MBED_ASSERT((settings.device.commInterface == IMU_MODE_I2C) ||
+	      (settings.device.commInterface == IMU_MODE_SPI));
+  
     // Whether we're using I2C or SPI, read a byte using the
     // gyro-specific I2C address or SPI CS pin.
     if (settings.device.commInterface == IMU_MODE_I2C)
@@ -1009,7 +1017,7 @@ uint8_t LSM9DS1::xgReadByte(uint8_t subAddress)
     else if (settings.device.commInterface == IMU_MODE_SPI)
         return SPIreadByte(_xgAddress, subAddress);
 
-    // Return 0 if the driver is misconfigured
+    // Return 0 if the driver is misconfigured (shouldn't reach this point)
     return 0;
 }
 
@@ -1026,6 +1034,10 @@ void LSM9DS1::xgReadBytes(uint8_t subAddress, uint8_t * dest, uint8_t count)
 
 uint8_t LSM9DS1::mReadByte(uint8_t subAddress)
 {
+    // Assert if the driver is misconfigured
+    MBED_ASSERT((settings.device.commInterface == IMU_MODE_I2C) ||
+	        (settings.device.commInterface == IMU_MODE_SPI));
+  
     // Whether we're using I2C or SPI, read a byte using the
     // accelerometer-specific I2C address or SPI CS pin.
     if (settings.device.commInterface == IMU_MODE_I2C)
@@ -1033,7 +1045,7 @@ uint8_t LSM9DS1::mReadByte(uint8_t subAddress)
     else if (settings.device.commInterface == IMU_MODE_SPI)
         return SPIreadByte(_mAddress, subAddress);
 
-    // Return 0 if the driver is misconfigured
+    // Return 0 if the driver is misconfigured (shouldn't reach this point)
     return 0;
     
 }

--- a/devices/ST/LSM9DS1/LSM9DS1.cpp
+++ b/devices/ST/LSM9DS1/LSM9DS1.cpp
@@ -1008,6 +1008,9 @@ uint8_t LSM9DS1::xgReadByte(uint8_t subAddress)
         return I2CreadByte(_xgAddress, subAddress);
     else if (settings.device.commInterface == IMU_MODE_SPI)
         return SPIreadByte(_xgAddress, subAddress);
+
+    // Return 0 if the driver is misconfigured
+    return 0;
 }
 
 void LSM9DS1::xgReadBytes(uint8_t subAddress, uint8_t * dest, uint8_t count)
@@ -1029,6 +1032,10 @@ uint8_t LSM9DS1::mReadByte(uint8_t subAddress)
         return I2CreadByte(_mAddress, subAddress);
     else if (settings.device.commInterface == IMU_MODE_SPI)
         return SPIreadByte(_mAddress, subAddress);
+
+    // Return 0 if the driver is misconfigured
+    return 0;
+    
 }
 
 void LSM9DS1::mReadBytes(uint8_t subAddress, uint8_t * dest, uint8_t count)


### PR DESCRIPTION
In some cases (eg: when the driver is misconfigured), a function with a non-void return type that is part of the LSM9DS1 driver may fail to return a value.

This fix addresses that condition by returning 0.