### PR TITLE
Prevent Span Overflow in ValueMapping API

### DIFF
--- a/extensions/dsp/ValueMapping.h
+++ b/extensions/dsp/ValueMapping.h
@@ -109,7 +109,7 @@ namespace ep
 
             // Above the range of the table
             if(x >= table[table.size()-1].x) {
-                return table[table.size()].y;
+                return table[table.size()-1].y;
             }
 
             // Find the closest values to the input x value


### PR DESCRIPTION
Fixes possible overflow when accessing a mapped value outside the upper range of the LUT values.

Resolves #11 