### PR TITLE
CallChain Link Type Extensions

### DIFF
--- a/extensions/CallChain.h
+++ b/extensions/CallChain.h
@@ -56,17 +56,14 @@ namespace ep {
             this->cb.call(args...);
         }
 
-        friend bool operator==(const CallChainLink<ArgTs...> &l1, const CallChainLink<ArgTs...> &l2);
-        friend bool operator!=(const CallChainLink<ArgTs...> &l1, const CallChainLink<ArgTs...> &l2);
-
-        bool operator==(const CallChainLink<ArgTs...> &l1, const CallChainLink<ArgTs...> &l2) {
+        virtual bool operator==(const CallChainLink<ArgTs...> &rhs) {
             // Compare based on Callback equivalency
-            return (l1.cb == l2.cb);
+            return (this->cb == rhs.cb);
         }
 
-        bool operator!=(const CallChainLink<ArgTs...> &l1, const CallChainLink<ArgTs...> &l2) {
+        virtual bool operator!=(const CallChainLink<ArgTs...> &rhs) {
             // Compare based on Callback equivalency
-            return (l1.cb != l2.cb);
+            return (this->cb != rhs.cb);
         }
 
     protected:

--- a/extensions/CallChain.h
+++ b/extensions/CallChain.h
@@ -76,8 +76,6 @@ namespace ep {
 	 * A linked-list structure of Callbacks that are triggered
 	 * by a common event.
 	 *
-	 * The Link template parameter defaults to a basic CallbackChainLink.
-	 *
 	 * If the application needs to add more information to the CallChainLink
 	 * (eg: an invidual threshold for each handler) it can do so by replacing
 	 * this Link type


### PR DESCRIPTION

Updates the CallChain API to allow the application to extend the information attached to each CallChainLink in the chain.

This lets the application/extension add things like parameter thresholds or other individual information as needed.

Backwards compatible change with `attach` and `detach` methods that accept `mbed::Callback` instances as input.

Admittedly sparse test log:

```
Running tests...
Test project /home/gdbeckstein/Documents/ep-oc-mcu-test/ep-oc-mcu/UNITTESTS/build
    Start 1: extensions-CallChain
1/1 Test #1: extensions-CallChain .............   Passed    0.00 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.00 sec
```
