### PR TITLE
Add support for TPS61165 in EasyScale

### DIFF
--- a/drivers/EasyScale.h
+++ b/drivers/EasyScale.h
@@ -37,6 +37,7 @@ class EasyScale
 	public:
 
 		static uint8_t DEVICE_ADDRESS_TPS61158;		/** Device address for TPS61158 backlight driver IC */
+		static uint8_t DEVICE_ADDRESS_TPS61165;     /** Device address for TPS61165 backlight driver IC */
 
 	public:
 

--- a/drivers/src/EasyScale.cpp
+++ b/drivers/src/EasyScale.cpp
@@ -34,6 +34,7 @@
 #define EASYSCALE_SHORT_DELAY_US 10
 
 uint8_t EasyScale::DEVICE_ADDRESS_TPS61158 = 0x58;
+uint8_t EasyScale::DEVICE_ADDRESS_TPS61165 = 0x72;
 
 EasyScale::EasyScale(PinName ctrl_pin) :
 							es_ctrl_pin(ctrl_pin, PIN_OUTPUT, PullNone, 0)


### PR DESCRIPTION
Update EasyScale with TPS61165 address constant. The TPS61165 is another backlight driver that supports the EasyScale protocol from TI.