### PR TITLE
Add driver support for NCV7608 octal hs/ls output driver

### DIFF
--- a/devices/NCV7608/NCV7608.cpp
+++ b/devices/NCV7608/NCV7608.cpp
@@ -1,8 +1,24 @@
-/*
- * NCV7608.cpp
+/**
+ * ep-oc-mcu
+ * Embedded Planet Open Core for Microcontrollers
  *
- *  Created on: Apr 24, 2020
- *      Author: gdbeckstein
+ * Built with ARM Mbed-OS
+ *
+ * Copyright (c) 2019-2020 Embedded Planet, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 #include "NCV7608.h"

--- a/devices/NCV7608/NCV7608.cpp
+++ b/devices/NCV7608/NCV7608.cpp
@@ -1,0 +1,169 @@
+/*
+ * NCV7608.cpp
+ *
+ *  Created on: Apr 24, 2020
+ *      Author: gdbeckstein
+ */
+
+#include "NCV7608.h"
+
+#include "mbed_assert.h"
+
+#define NCV7608_TW_BIT (1 << 0)
+#define NCV7608_VS_DIAG_BIT (1 << 15)
+
+using namespace ep;
+
+NCV7608::NCV7608(mbed::SPI& spi, PinName csb, PinName global_en) :
+        _spi(spi), _cs(nullptr), _global_en(nullptr),
+        _cached_state(0), _cached_diag(0) {
+
+    // Instantiate optional control outputs
+    if (csb != NC) {
+        _cs = new mbed::DigitalOut(csb, 1);
+    }
+
+    if (global_en != NC) {
+        // Disabled by default
+        _global_en = new mbed::DigitalOut(global_en, 0);
+    }
+}
+
+NCV7608::~NCV7608(void) {
+    // Clean up any dynamically allocated members
+    if (_cs != nullptr) {
+        delete _cs;
+    }
+
+    if (_global_en != nullptr) {
+        delete _global_en;
+    }
+}
+
+void NCV7608::enable(void) {
+    if (_global_en != nullptr) {
+        *_global_en = 1;
+    }
+
+    // Turn off all channels initially
+    batch_write(0);
+}
+
+void NCV7608::disable(void) {
+    if (_global_en != nullptr) {
+        *_global_en = 0;
+    }
+}
+
+void ep::NCV7608::assert_cs(void) {
+    if (_cs != nullptr) {
+        *_cs = 0;
+    }
+}
+
+void ep::NCV7608::deassert_cs(void) {
+    if (_cs != nullptr) {
+        *_cs = 1;
+    }
+}
+
+NCV7608::ChannelOut NCV7608::channel(int num) {
+    return ChannelOut(*this, num);
+}
+
+uint16_t NCV7608::batch_write(uint8_t channel_bits, uint8_t ol_bits) {
+    assert_cs();
+    _cached_state = ((ol_bits << 8) | channel_bits);
+    _cached_diag = _spi.write(_cached_state);
+    deassert_cs();
+    return _cached_diag;
+}
+
+NCV7608::ChannelOut::ChannelOut(NCV7608& ncv7608, int channel_num) :
+        _parent(ncv7608), _num(channel_num) {
+    // Only channels 1 through 8 are supported
+    MBED_ASSERT((0 < channel_num) && (channel_num <= 8));
+}
+
+void NCV7608::ChannelOut::write(int value) {
+    // Get the cached channel states
+    uint16_t new_state = _parent.get_cached_state();
+
+    // Set or clear the channel as indicated by value
+    if (value) {
+        // Set the channel enable bit
+        new_state |= (1 << _num);
+    } else {
+        // Clear the channel enable bit
+        new_state &= ~(1 << _num);
+    }
+
+    // Write out the value
+    _parent.batch_write((uint8_t) (new_state & 0xFF),
+            (uint8_t) ((new_state & 0xFF00) >> 8));
+
+}
+
+int NCV7608::ChannelOut::read() {
+    return (_parent.get_cached_state() & (1 << _num));
+}
+
+NCV7608::fault_condition_t NCV7608::ChannelOut::get_fault(void) {
+
+    uint16_t diag_bits = _parent.get_cached_diag();
+
+    // First see if there's a fault reported on this channel
+    if(!(diag_bits & (1 << (_num + 1)))) {
+        // No fault, return here
+        return NO_FAULT;
+    }
+
+    // Okay, fault bit is set. Determine what caused it
+
+    /**
+     * Open load fault can only be detected when the channel is off
+     * and the open load detection enable bit is set
+     */
+    if(this->is_off() && this->open_load_diag_enabled()) {
+        return OPEN_LOAD;
+    }
+
+    /** Thermal fault is indicated globally, so check if that bit is set
+     */
+    if(diag_bits & NCV7608_TW_BIT) {
+        return THERMAL_FAULT;
+    }
+
+     /** Otherwise, it must be an over-current fault
+     */
+    return OVER_CURRENT;
+}
+
+void NCV7608::ChannelOut::enable_open_load_diag(void) {
+    // Get the cached channel states
+    uint16_t new_state = _parent.get_cached_state();
+
+    // Set the channel ol enable bit
+    new_state |= (1 << (_num + 8));
+
+    // Write out the value
+    _parent.batch_write((uint8_t) (new_state & 0xFF),
+            (uint8_t) ((new_state & 0xFF00) >> 8));
+}
+
+void NCV7608::ChannelOut::disable_open_load_diag(void) {
+    // Get the cached channel states
+    uint16_t new_state = _parent.get_cached_state();
+
+    // Clear the channel ol enable bit
+    new_state &= ~(1 << (_num + 8));
+
+    // Write out the value
+    _parent.batch_write((uint8_t) (new_state & 0xFF),
+            (uint8_t) ((new_state & 0xFF00) >> 8));
+}
+
+bool NCV7608::ChannelOut::open_load_diag_enabled(void) {
+    return (_parent.get_cached_state() & (1 << (_num + 8)));
+}
+

--- a/devices/NCV7608/NCV7608.cpp
+++ b/devices/NCV7608/NCV7608.cpp
@@ -87,11 +87,11 @@ NCV7608::ChannelOut NCV7608::channel(int num) {
     return ChannelOut(*this, num);
 }
 
-uint16_t NCV7608::batch_write(uint8_t channel_bits, uint8_t ol_bits) {
+uint16_t NCV7608::batch_write(uint16_t new_state) {
 
     assert_cs();
 
-    _cached_state = ((channel_bits << 8) | ol_bits);
+    _cached_state = new_state;
 
     uint16_t diag_flipped = _spi.write(_cached_state);
     _cached_diag = ((diag_flipped & 0xFF00) >> 8);
@@ -102,8 +102,7 @@ uint16_t NCV7608::batch_write(uint8_t channel_bits, uint8_t ol_bits) {
 }
 
 uint16_t NCV7608::sync(void) {
-    return batch_write((uint8_t) ((_cached_state & 0xFF00) >> 8),
-            (uint8_t) (_cached_state & 0x00FF));
+    return batch_write(_cached_state);
 }
 
 NCV7608::ChannelOut::ChannelOut(NCV7608& ncv7608, int channel_num) :
@@ -130,8 +129,7 @@ void NCV7608::ChannelOut::write(int value) {
     }
 
     // Write out the value
-    _parent.batch_write((uint8_t) ((new_state & 0xFF00) >> 8),
-            (uint8_t) (new_state & 0x00FF));
+    _parent.batch_write(new_state);
 
     // Unlock the device mutex
     _parent.mutex.unlock();
@@ -192,8 +190,7 @@ void NCV7608::ChannelOut::enable_open_load_diag(void) {
     new_state |= (0x80 >> _num);
 
     // Write out the value
-    _parent.batch_write((uint8_t) ((new_state & 0xFF00) >> 8),
-            (uint8_t) (new_state & 0x00FF));
+    _parent.batch_write(new_state);
 
     // Unlock the device mutex
     _parent.mutex.unlock();
@@ -211,8 +208,7 @@ void NCV7608::ChannelOut::disable_open_load_diag(void) {
     new_state &= ~(0x80 >> _num);
 
     // Write out the value
-    _parent.batch_write((uint8_t) ((new_state & 0xFF00) >> 8),
-            (uint8_t) (new_state & 0x00FF));
+    _parent.batch_write(new_state);
 
     // Unlock the device mutex
     _parent.mutex.unlock();

--- a/devices/NCV7608/NCV7608.cpp
+++ b/devices/NCV7608/NCV7608.cpp
@@ -92,10 +92,7 @@ uint16_t NCV7608::batch_write(uint16_t new_state) {
     assert_cs();
 
     _cached_state = new_state;
-
-    uint16_t diag_flipped = _spi.write(_cached_state);
-    _cached_diag = ((diag_flipped & 0xFF00) >> 8);
-    _cached_diag |= ((diag_flipped & 0xFF) << 8);
+    _cached_diag = _spi.write(_cached_state);
 
     deassert_cs();
     return _cached_diag;
@@ -152,7 +149,7 @@ NCV7608::fault_condition_t NCV7608::ChannelOut::get_fault(void) {
     _parent.mutex.unlock();
 
     // First see if there's a fault reported on this channel
-    if (!(diag_bits & (0x80 >> (_num + 1)))) {
+    if (!(diag_bits & (0x4000 >> _num))) {
         // No fault, return here
         return NO_FAULT;
     }

--- a/devices/NCV7608/NCV7608.h
+++ b/devices/NCV7608/NCV7608.h
@@ -1,8 +1,24 @@
-/*
- * NCV7608.h
+/**
+ * ep-oc-mcu
+ * Embedded Planet Open Core for Microcontrollers
  *
- *  Created on: Apr 24, 2020
- *      Author: gdbeckstein
+ * Built with ARM Mbed-OS
+ *
+ * Copyright (c) 2019-2020 Embedded Planet, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
  */
 
 #ifndef EP_OC_MCU_DEVICES_NCV7608_NCV7608_H_
@@ -224,7 +240,7 @@ public:
      * using multiple outputs in a motor control application.
      *
      * @param[in] channel_bits Each desired channel state is represented by
-     * a bit in this number. The bit corresponds to channel (bit_pos) - 7.
+     * a bit in this number. The bit corresponds to channel ((7 - bit_pos) + 1).
      * (eg: bit 7 represents the desired state of channel 1, 1 = on, 0 = off)
      *
      * @param[in] open_load_en Similar to channel bits, each bit in this

--- a/devices/NCV7608/NCV7608.h
+++ b/devices/NCV7608/NCV7608.h
@@ -233,7 +233,7 @@ public:
      * state of each channel. If you are using the ChannelOut API there are
      * convenience functions to interpret this information for you.
      */
-    uint16_t batch_write(uint8_t channel_bits, uint8_t ol_bits = 0xFF);
+    uint16_t batch_write(uint8_t channel_bits, uint8_t ol_bits = 0x00);
 
 protected:
 

--- a/devices/NCV7608/NCV7608.h
+++ b/devices/NCV7608/NCV7608.h
@@ -1,0 +1,277 @@
+/*
+ * NCV7608.h
+ *
+ *  Created on: Apr 24, 2020
+ *      Author: gdbeckstein
+ */
+
+#ifndef EP_OC_MCU_DEVICES_NCV7608_NCV7608_H_
+#define EP_OC_MCU_DEVICES_NCV7608_NCV7608_H_
+
+#include "drivers/SPI.h"
+#include "drivers/DigitalOut.h"
+
+namespace ep {
+
+/**
+ * The NCV7608 is an automotive-grade, configurable,
+ * octal low-side/high-side driver that can be controlled using a
+ * 16-bit SPI bus.
+ *
+ * The NCV7608 has built-in protection, including flyback diodes, ESD,
+ * over-temperature, and over-current. Each failure mode can be diagnosed
+ * through the SPI bus interface.
+ *
+ * The built-in protection features and configurable HS/LS outputs
+ * make the NCV7608 ideal for driving resistive (eg: indicator lamps)
+ * as well as inductive (eg: relays, small solenoids, DC motors, stepper motors)
+ * loads. It is possible to configure the NCV7608 as an H-bridge driver
+ *
+ */
+class NCV7608 {
+
+public:
+
+    /**
+     * Important notes on NCV7608 fault detection:
+     * - Open load faults can only be detected with the channel OFF
+     * - Thermal warning is a global bit, so if a channel activates the thermal
+     * warning bit while another channel is exhibiting a different fault, the
+     * latter channel will also be reported as having triggered the thermal fault
+     */
+    typedef enum {
+        NO_FAULT,           /** No fault condition */
+        OPEN_LOAD,          /** Open load condition exists on channel */
+        OVER_CURRENT,       /** Over-current condition exists on channel */
+        THERMAL_FAULT,      /** Thermal fault (includes thermal warning/shutdown) */
+        VS_POWER_FAIL,      /** Supply voltage power failure detected */
+    } fault_condition_t;
+
+    /**
+     * Convenience class similar to DigitalOut
+     */
+    class ChannelOut {
+
+    public:
+
+        /**
+         * Construct a ChannelOut
+         * @param[in] ncv7608 Parent ncv7608 instance
+         * @param[in] num Channel number
+         *
+         * @note the preferred method create a ChannelOut is
+         * to use ::channel on the given NCV7608 instance
+         */
+        ChannelOut(NCV7608& ncv7608, int num);
+
+        /** Set the output off or on, specified as 0 or 1 (int), respectively
+         *
+         *  @param value An integer specifying the pin output value,
+         *      0 for logical 0, 1 (or any other non-zero value) for logical 1
+         */
+        void write(int value);
+
+        /** Return the output setting, represented as 0 or 1 (int)
+         *
+         *  @returns
+         *    an integer representing the output setting of the pin,
+         *    0 for logical 0, 1 for logical 1
+         */
+        int read();
+
+        /**
+         * Gets the fault condition of the channel
+         *
+         * @note this does not check the PWM input status bits
+         *
+         * @note If a fault is reported on a channel, you
+         * must typically disable the channel and then re-enable
+         * the channel to reset the fault condition. This will only
+         * work if the cause of the fault is also removed.
+         */
+        fault_condition_t get_fault(void);
+
+        /**
+         * Enables the open load diagnostics on this channel
+         */
+        void enable_open_load_diag(void);
+
+        /**
+         * Disables the open load diagnostics on this channel
+         */
+        void disable_open_load_diag(void);
+
+        /**
+         * Checks if open load diagnostics are enabled on this channel
+         */
+        bool open_load_diag_enabled(void);
+
+        /**
+         * Set the output to on
+         */
+        inline void on(void) {
+            write(1);
+        }
+
+        /**
+         * Set the output to off
+         */
+        inline void off(void) {
+            write(0);
+        }
+
+        /**
+         * Returns true if current state of channel is on
+         */
+        inline bool is_on(void) {
+            return (read() == 1);
+        }
+
+        /**
+         * Returns true if current state of channel is off
+         */
+        inline bool is_off(void) {
+            return (read() == 0);
+        }
+
+        /** A shorthand for write()
+         * \sa ChannelOut::write()
+         * @code
+         *      ChannelOut led(LED1);
+         *      led = 1;   // Equivalent to led.write(1)
+         * @endcode
+         */
+        ChannelOut &operator=(int value) {
+            // Underlying write is thread safe
+            write(value);
+            return *this;
+        }
+
+        /** A shorthand for write() using the assignment operator which copies the
+         * state from the DigitalOut argument.
+         * \sa DigitalOut::write()
+         */
+        ChannelOut &operator=(ChannelOut &rhs) {
+            write(rhs.read());
+            return *this;
+        }
+
+        /** A shorthand for read()
+         * \sa DigitalOut::read()
+         */
+        operator int() {
+            // Underlying call is thread safe
+            return read();
+        }
+
+    protected:
+        NCV7608& _parent; /** Parent NCV7608 of this channel object */
+        int _num; /** Channel number of this object (1-8) */
+
+    };
+
+public:
+
+    /** Allow ChannelOut to access internal members */
+    friend class ChannelOut;
+
+    /**
+     * Instantiate an NCV7608 driver
+     * @param[in] spi SPI bus instance to use for communication (16-bit format!)
+     * @param[in] csb Chip select "bar", defaults to NC (CS handled by SPI in this case)
+     * @param[in] global_en Global enable pin, defaults to NC (unused)
+     *
+     * @note The SPI bus instance used must be configured for 16-bit format
+     * to work properly!
+     */
+    NCV7608(mbed::SPI& spi, PinName csb = NC, PinName global_en = NC);
+
+    /**
+     * Destructor
+     */
+    ~NCV7608(void);
+
+    /**
+     * Globally enable (if global_en != NC)
+     */
+    void enable(void);
+
+    /**
+     * Globally disable (if global_en != NC)
+     */
+    void disable(void);
+
+    /**
+     * Convenience function to create a ChannelOut object for a given
+     * channel
+     *
+     * @param[in] num Desired channel number. Allowed values: 1 thru 8
+     * @retval channel Reference to channel
+     */
+    ChannelOut channel(int num);
+
+    /**
+     * Batch writes channel settings to the NCV7608
+     *
+     * If your application requires closely-timed output transitions,
+     * this function ensures the output states are updated in the same
+     * SPI transaction.
+     *
+     * This is useful if, for example, you are using two outputs in
+     * parallel to achieve a higher current capacity or you are
+     * using multiple outputs in a motor control application.
+     *
+     * @param[in] channel_bits Each desired channel state is represented by
+     * a bit in this number. The bit corresponds to channel (bit_pos) + 1.
+     * (eg: bit 0 represents the desired state of channel 1, 1 = on, 0 = off)
+     *
+     * @param[in] open_load_en Similar to channel bits, each bit in this
+     * number represents whether open-load diagnostics are desired on
+     * the given channel. 0 = not enabled, 1 = enabled. Defaults to enabled.
+     *
+     * @retval diag_bits 16-bit output from NCV7608 representing the diagnostics
+     * state of each channel. If you are using the ChannelOut API there are
+     * convenience functions to interpret this information for you.
+     */
+    uint16_t batch_write(uint8_t channel_bits, uint8_t ol_bits = 0xFF);
+
+protected:
+
+    /**
+     * Asserts the chip select line, if separate from SPI instance
+     */
+    void assert_cs(void);
+
+    /**
+     * Deasserts the chip select line, if separate from SPI instance
+     */
+    void deassert_cs(void);
+
+    /**
+     * Returns the cached channel state
+     */
+    uint16_t get_cached_state(void) {
+        return _cached_state;
+    }
+
+    /**
+     * Returns the cached diagnostics bits
+     */
+    uint16_t get_cached_diag(void) {
+        return _cached_diag;
+    }
+
+protected:
+
+    mbed::SPI& _spi;
+    mbed::DigitalOut* _cs;
+    mbed::DigitalOut* _global_en;
+
+    uint16_t _cached_state; /** Cached channel on/off state bits */
+    uint16_t _cached_diag;  /** Cached diagnostics bits */
+
+};
+
+}
+
+#endif /* EP_OC_MCU_DEVICES_NCV7608_NCV7608_H_ */

--- a/devices/NCV7608/NCV7608.h
+++ b/devices/NCV7608/NCV7608.h
@@ -11,6 +11,8 @@
 #include "drivers/SPI.h"
 #include "drivers/DigitalOut.h"
 
+#include "platform/PlatformMutex.h"
+
 namespace ep {
 
 /**
@@ -261,6 +263,11 @@ protected:
         return _cached_diag;
     }
 
+    /**
+     * Sync the cached state and diagnostic bits
+     */
+    uint16_t sync(void);
+
 protected:
 
     mbed::SPI& _spi;
@@ -269,6 +276,8 @@ protected:
 
     uint16_t _cached_state; /** Cached channel on/off state bits */
     uint16_t _cached_diag;  /** Cached diagnostics bits */
+
+    PlatformMutex mutex;
 
 };
 

--- a/devices/NCV7608/NCV7608.h
+++ b/devices/NCV7608/NCV7608.h
@@ -239,19 +239,29 @@ public:
      * parallel to achieve a higher current capacity or you are
      * using multiple outputs in a motor control application.
      *
-     * @param[in] channel_bits Each desired channel state is represented by
-     * a bit in this number. The bit corresponds to channel ((7 - bit_pos) + 1).
-     * (eg: bit 7 represents the desired state of channel 1, 1 = on, 0 = off)
-     *
-     * @param[in] open_load_en Similar to channel bits, each bit in this
-     * number represents whether open-load diagnostics are desired on
-     * the given channel. 0 = not enabled, 1 = enabled. Defaults to disabled.
+     * @param[in] new_state Each desired channel state is represented by
+     * a bit in the MSB of this number. The bit corresponds to channel ((15 - bit_pos) + 1).
+     * (eg: bit 15 represents the desired state of channel 1, 1 = on, 0 = off)
+     * Each bit in the LSB of this number represents whether open-load diagnostics are
+     * desired on the given channel. 0 = not enabled, 1 = enabled.
+     * Defaults to disabled.
      *
      * @retval diag_bits 16-bit output from NCV7608 representing the diagnostics
      * state of each channel. If you are using the ChannelOut API there are
      * convenience functions to interpret this information for you.
+     *
+     * @note The open-load diagnostics only work with the channel off. Due
+     * to the way they work, enabling open-load diagnostics may sink enough
+     * current to dimly illuminate LED loads. This is why it defaults to off.
      */
-    uint16_t batch_write(uint8_t channel_bits, uint8_t ol_bits = 0x00);
+    uint16_t batch_write(uint16_t new_state);
+
+    /**
+     * Returns the cached channel state
+     */
+    uint16_t get_cached_state(void) {
+        return _cached_state;
+    }
 
 protected:
 
@@ -264,13 +274,6 @@ protected:
      * Deasserts the chip select line, if separate from SPI instance
      */
     void deassert_cs(void);
-
-    /**
-     * Returns the cached channel state
-     */
-    uint16_t get_cached_state(void) {
-        return _cached_state;
-    }
 
     /**
      * Returns the cached diagnostics bits

--- a/devices/NCV7608/NCV7608.h
+++ b/devices/NCV7608/NCV7608.h
@@ -224,12 +224,12 @@ public:
      * using multiple outputs in a motor control application.
      *
      * @param[in] channel_bits Each desired channel state is represented by
-     * a bit in this number. The bit corresponds to channel (bit_pos) + 1.
-     * (eg: bit 0 represents the desired state of channel 1, 1 = on, 0 = off)
+     * a bit in this number. The bit corresponds to channel (bit_pos) - 7.
+     * (eg: bit 7 represents the desired state of channel 1, 1 = on, 0 = off)
      *
      * @param[in] open_load_en Similar to channel bits, each bit in this
      * number represents whether open-load diagnostics are desired on
-     * the given channel. 0 = not enabled, 1 = enabled. Defaults to enabled.
+     * the given channel. 0 = not enabled, 1 = enabled. Defaults to disabled.
      *
      * @retval diag_bits 16-bit output from NCV7608 representing the diagnostics
      * state of each channel. If you are using the ChannelOut API there are


### PR DESCRIPTION
This PR adds support for the NCV7608, an automotive-grade, SPI-enabled (16-bit), configurable, octal high-side/low-side driver from On Semiconductor.