### PR TITLE
Add NCV7751

### DIFF
--- a/devices/NCV7608/NCV7608.cpp
+++ b/devices/NCV7608/NCV7608.cpp
@@ -111,7 +111,7 @@ NCV7608::ChannelOut::ChannelOut(NCV7608& ncv7608, int channel_num) :
 void NCV7608::ChannelOut::write(int value) {
 
     // Lock the device mutex
-    _parent.mutex.lock();
+    _parent._mutex.lock();
 
     // Get the cached channel states
     uint16_t new_state = _parent.get_cached_state();
@@ -129,7 +129,7 @@ void NCV7608::ChannelOut::write(int value) {
     _parent.batch_write(new_state);
 
     // Unlock the device mutex
-    _parent.mutex.unlock();
+    _parent._mutex.unlock();
 
 }
 
@@ -140,13 +140,13 @@ int NCV7608::ChannelOut::read() {
 NCV7608::fault_condition_t NCV7608::ChannelOut::get_fault(void) {
 
     // Lock the device mutex
-    _parent.mutex.lock();
+    _parent._mutex.lock();
 
     // Sync diagnostic bits
     uint16_t diag_bits = _parent.sync();
 
     // Unlock the device mutex
-    _parent.mutex.unlock();
+    _parent._mutex.unlock();
 
     // First see if there's a fault reported on this channel
     if (!(diag_bits & (0x4000 >> _num))) {
@@ -178,7 +178,7 @@ NCV7608::fault_condition_t NCV7608::ChannelOut::get_fault(void) {
 void NCV7608::ChannelOut::enable_open_load_diag(void) {
 
     // Lock the device mutex
-    _parent.mutex.lock();
+    _parent._mutex.lock();
 
     // Get the cached channel states
     uint16_t new_state = _parent.get_cached_state();
@@ -190,13 +190,13 @@ void NCV7608::ChannelOut::enable_open_load_diag(void) {
     _parent.batch_write(new_state);
 
     // Unlock the device mutex
-    _parent.mutex.unlock();
+    _parent._mutex.unlock();
 }
 
 void NCV7608::ChannelOut::disable_open_load_diag(void) {
 
     // Lock the device mutex
-    _parent.mutex.lock();
+    _parent._mutex.lock();
 
     // Get the cached channel states
     uint16_t new_state = _parent.get_cached_state();
@@ -208,7 +208,7 @@ void NCV7608::ChannelOut::disable_open_load_diag(void) {
     _parent.batch_write(new_state);
 
     // Unlock the device mutex
-    _parent.mutex.unlock();
+    _parent._mutex.unlock();
 
 }
 

--- a/devices/NCV7608/NCV7608.cpp
+++ b/devices/NCV7608/NCV7608.cpp
@@ -89,12 +89,19 @@ NCV7608::ChannelOut NCV7608::channel(int num) {
 
 uint16_t NCV7608::batch_write(uint16_t new_state) {
 
+    // Lock the SPI mutex before asserting CS
+    _spi.lock();
+
     assert_cs();
 
     _cached_state = new_state;
     _cached_diag = _spi.write(_cached_state);
 
     deassert_cs();
+
+    // Unlock the SPI mutex
+    _spi.unlock();
+
     return _cached_diag;
 }
 

--- a/devices/NCV7608/NCV7608.h
+++ b/devices/NCV7608/NCV7608.h
@@ -296,7 +296,7 @@ protected:
     uint16_t _cached_state; /** Cached channel on/off state bits */
     uint16_t _cached_diag;  /** Cached diagnostics bits */
 
-    PlatformMutex mutex;
+    PlatformMutex _mutex;
 
 };
 

--- a/devices/NCV7751/NCV7751.cpp
+++ b/devices/NCV7751/NCV7751.cpp
@@ -11,34 +11,33 @@
 
 using namespace ep;
 
-NCV7751::NCV7751(mbed::SPI& spi, PinName csb1, PinName csb2,
-        PinName global_en) : _spi(spi), _csb1(csb1, 1),
-                _csb2(csb2, 1), _global_en(nullptr),
-                _cached_state(0), _cached_diag(0) {
+NCV7751::NCV7751(mbed::SPI& spi, PinName csb1, PinName csb2, PinName global_en) :
+        _spi(spi), _csb1(csb1, 1), _csb2(csb2, 1), _global_en(nullptr), _channel_bits(
+                0), _ol_bits(0), _cached_diag(0) {
     // Instantiate optional control outputs
-    if(global_en != NC) {
+    if (global_en != NC) {
         _global_en = new mbed::DigitalOut(global_en, 0);
     }
 }
 
 NCV7751::~NCV7751(void) {
     // Clean up any dynamically allocated members
-    if(_global_en != nullptr) {
+    if (_global_en != nullptr) {
         delete _global_en;
     }
 }
 
 void NCV7751::enable(void) {
-    if(_global_en != nullptr) {
+    if (_global_en != nullptr) {
         *_global_en = 1;
     }
 
     // Turn off all channels initially
-    batch_write(0);
+    write_state(0);
 }
 
 void NCV7751::disable(void) {
-    if(_global_en != nullptr) {
+    if (_global_en != nullptr) {
         *_global_en = 0;
     }
 }
@@ -47,10 +46,39 @@ NCV7751::ChannelOut NCV7751::channel(int num) {
     return ChannelOut(*this, num);
 }
 
-uint32_t NCV7751::batch_write(uint16_t channel_bits, uint16_t ol_bits) {
-}
+uint32_t NCV7751::write_state(uint16_t channel_bits, uint16_t ol_bits) {
 
-uint32_t NCV7751::write_state(uint32_t state) {
+    _mutex.lock();
+
+    _channel_bits = channel_bits;
+    _ol_bits = ol_bits;
+
+    // Format the channel/ol bits to NCV7751 format
+    uint16_t si_port1 = 0, si_port2 = 0;
+    for(int i = 0; i < 16; i++) {
+
+        // Select the port this channel is controlled by
+        uint16_t* port = (i <= 7? &si_port1 : &si_port2);
+
+        /**
+         * If the channel is set to on, ignore the ol bits
+         * Open-load diagnostics are only enabled when channel is off
+         */
+        if(_channel_bits & (1 << i)) {
+            // Set the channel to ON mode (0b10)
+            port |= (1 << ((i << 1) + 1)); // 1 << ((i * 2) + 1)
+            port &= ~(1 << (i << 1));
+        } else if(_ol_bits & (1 << i)) {
+            // Check if open-load diagnostics are enabled
+            // If so, set channel to OFF mode (0b11)
+            port |= (0b11 << (i << 1)); // i * 2
+        } else {
+            // Neither channel nor ol diag are enabled
+            // Set channel to STANDBY mode (0b00)
+            port &= ~(0b11 << (i << 1));
+        }
+
+    }
 
     /**
      * Access Channels 1 thru 8
@@ -58,7 +86,7 @@ uint32_t NCV7751::write_state(uint32_t state) {
      */
     _csb1 = 1;
     _csb2 = 0;
-    uint32_t serial_out = _spi.write((uint16_t)(state & 0xFFFF));
+    _cached_diag = (_spi.write(si_port1) & 0xFFFF);
     /**
      * Access Channels 9 thru 12
      * CSB Mode = 0b01_T
@@ -66,18 +94,23 @@ uint32_t NCV7751::write_state(uint32_t state) {
     _csb2 = 1;
     _csb1 = 0;
     // T = truncated (16-bit vs 24-bit), internal register setting
-    serial_out |= (((_spi.write((uint16_t)((state & 0xFFFF0000) >> 16)))
-            & 0xFF00) << 12);
+    _cached_diag |= (((_spi.write(si_port2)) & 0xFF00) << 12);
 
     /** Deassert */
     _csb1 = 1;
 
-    return serial_out;
+    _mutex.unlock();
+
+    return _cached_diag;
 
 }
 
+uint32_t NCV7751::sync(void) {
+    return write_state(_channel_bits, _ol_bits);
+}
+
 NCV7751::ChannelOut::ChannelOut(NCV7751& ncv7751, int channel_num) :
-    _parent(ncv7751), _num(channel_num) {
+        _parent(ncv7751), _num(channel_num - 1) {
     // Only channels 1 through 12 are supported
     MBED_ASSERT((0 < channel_num) && (channel_num <= 12));
 }
@@ -87,36 +120,57 @@ void NCV7751::ChannelOut::write(int value) {
     _parent._mutex.lock();
 
     // Get the cached channel states
-    uint16_t new_state = _parent.get_cached_state();
+    uint16_t new_channel_bits = _parent.get_channel_bits();
 
     // Set or clear the channel as indicated by value
-    if(value) {
-
-        // Set the channel mode to 10 (ON mode)
-        new_state |= (1  << ((_num -1) << 1)+1);    // ((_num - 1) * 2) + 1
-        new_state &= ~(1 << ((_num-1) << 1));       // ((_num -1) * 2)
+    if (value) {
+        // Set the channel on bit
+        new_channel_bits |= (1 << _num);
+    } else {
+        // Clear the channel on bit
+        new_channel_bits &= ~(1 << _num);
     }
 
     // Write out the value
-    _parent.write_state(new_state);
+    _parent.write_state(new_channel_bits, _parent.get_ol_bits());
 
     _parent._mutex.unlock();
 }
 
 int NCV7751::ChannelOut::read() {
-
-    // TODO - get bitmask for a given channel number
-    uint32_t state = _parent.get_cached_state();
+    return (_parent.get_channel_bits() & (1 << _num));
 }
 
 NCV7751::fault_condition_t NCV7751::ChannelOut::get_fault(void) {
+
+    // Lock the device mutex
+    _parent._mutex.lock();
+
+    // Sync diagnostic bits
+    uint32_t diag_bits = _parent.sync();
+
+    // Unlock the device mutex
+    _parent._mutex.unlock();
+
+    // First see if there's a fault reported on this channel
+    return NO_FAULT;
+
 }
 
 void NCV7751::ChannelOut::enable_open_load_diag(void) {
+    uint16_t new_ol_bits = _parent.get_ol_bits();
+    new_ol_bits |= (1 << _num);
+
+    _parent.write_state(_parent.get_channel_bits(), new_ol_bits);
 }
 
 void NCV7751::ChannelOut::disable_open_load_diag(void) {
+    uint16_t new_ol_bits = _parent.get_ol_bits();
+    new_ol_bits &= ~(1 << _num);
+
+    _parent.write_state(_parent.get_channel_bits(), new_ol_bits);
 }
 
 bool NCV7751::ChannelOut::open_load_diag_enabled(void) {
+    return (_parent.get_ol_bits() & (1 << _num));
 }

--- a/devices/NCV7751/NCV7751.cpp
+++ b/devices/NCV7751/NCV7751.cpp
@@ -1,0 +1,122 @@
+/*
+ * NCV7751.cpp
+ *
+ *  Created on: Apr 24, 2020
+ *      Author: gdbeckstein
+ */
+
+#include "NCV7751.h"
+
+#include "mbed_assert.h"
+
+using namespace ep;
+
+NCV7751::NCV7751(mbed::SPI& spi, PinName csb1, PinName csb2,
+        PinName global_en) : _spi(spi), _csb1(csb1, 1),
+                _csb2(csb2, 1), _global_en(nullptr),
+                _cached_state(0), _cached_diag(0) {
+    // Instantiate optional control outputs
+    if(global_en != NC) {
+        _global_en = new mbed::DigitalOut(global_en, 0);
+    }
+}
+
+NCV7751::~NCV7751(void) {
+    // Clean up any dynamically allocated members
+    if(_global_en != nullptr) {
+        delete _global_en;
+    }
+}
+
+void NCV7751::enable(void) {
+    if(_global_en != nullptr) {
+        *_global_en = 1;
+    }
+
+    // Turn off all channels initially
+    batch_write(0);
+}
+
+void NCV7751::disable(void) {
+    if(_global_en != nullptr) {
+        *_global_en = 0;
+    }
+}
+
+NCV7751::ChannelOut NCV7751::channel(int num) {
+    return ChannelOut(*this, num);
+}
+
+uint32_t NCV7751::batch_write(uint16_t channel_bits, uint16_t ol_bits) {
+}
+
+uint32_t NCV7751::write_state(uint32_t state) {
+
+    /**
+     * Access Channels 1 thru 8
+     * CSB Mode = 0b10
+     */
+    _csb1 = 1;
+    _csb2 = 0;
+    uint32_t serial_out = _spi.write((uint16_t)(state & 0xFFFF));
+    /**
+     * Access Channels 9 thru 12
+     * CSB Mode = 0b01_T
+     */
+    _csb2 = 1;
+    _csb1 = 0;
+    // T = truncated (16-bit vs 24-bit), internal register setting
+    serial_out |= (((_spi.write((uint16_t)((state & 0xFFFF0000) >> 16)))
+            & 0xFF00) << 12);
+
+    /** Deassert */
+    _csb1 = 1;
+
+    return serial_out;
+
+}
+
+NCV7751::ChannelOut::ChannelOut(NCV7751& ncv7751, int channel_num) :
+    _parent(ncv7751), _num(channel_num) {
+    // Only channels 1 through 12 are supported
+    MBED_ASSERT((0 < channel_num) && (channel_num <= 12));
+}
+
+void NCV7751::ChannelOut::write(int value) {
+
+    _parent._mutex.lock();
+
+    // Get the cached channel states
+    uint16_t new_state = _parent.get_cached_state();
+
+    // Set or clear the channel as indicated by value
+    if(value) {
+
+        // Set the channel mode to 10 (ON mode)
+        new_state |= (1  << ((_num -1) << 1)+1);    // ((_num - 1) * 2) + 1
+        new_state &= ~(1 << ((_num-1) << 1));       // ((_num -1) * 2)
+    }
+
+    // Write out the value
+    _parent.write_state(new_state);
+
+    _parent._mutex.unlock();
+}
+
+int NCV7751::ChannelOut::read() {
+
+    // TODO - get bitmask for a given channel number
+    uint32_t state = _parent.get_cached_state();
+}
+
+NCV7751::fault_condition_t NCV7751::ChannelOut::get_fault(void) {
+}
+
+void NCV7751::ChannelOut::enable_open_load_diag(void) {
+}
+
+void NCV7751::ChannelOut::disable_open_load_diag(void) {
+}
+
+bool NCV7751::ChannelOut::open_load_diag_enabled(void) {
+}

--- a/devices/NCV7751/NCV7751.h
+++ b/devices/NCV7751/NCV7751.h
@@ -1,0 +1,277 @@
+/*
+ * NCV7751.h
+ *
+ *  Created on: Apr 24, 2020
+ *      Author: gdbeckstein
+ */
+
+#ifndef EP_OC_MCU_DEVICES_NCV7751_NCV7751_H_
+#define EP_OC_MCU_DEVICES_NCV7751_NCV7751_H_
+
+#include "drivers/SPI.h"
+#include "drivers/DigitalOut.h"
+
+#include "platform/PlatformMutex.h"
+
+namespace ep {
+
+/**
+ * The NCV7751 is an automotive-grade 12-channel low-side output driver
+ * that can be controlled over SPI.
+ *
+ * The NCV7751 has built-in protection, including flyback diodes, ESD,
+ * over-current, over temperature, and open load detection. The cause of
+ * failure can be diagnosed through the SPI bus interface.
+ *
+ * The built-in protection features and large number of outputs
+ * make the NCV7751 ideal for driving resistive as well as inductive loads
+ * in an automotive setting while minimizing BOM complexity. It is especially
+ * useful in I/O-constrained applications.
+ *
+ */
+class NCV7751
+{
+
+
+public:
+
+    /**
+     *
+     */
+    typedef enum {
+        NO_FAULT,           /** No fault condition */
+        OPEN_LOAD,          /** Open load condition exists on channel */
+        OVER_LOAD,          /** Over-load condition exists on channel */
+        OVER_TEMPERATURE,   /** Over temperature fault */
+    } fault_condition_t;
+
+    /**
+     * Convenience class similar to DigitalOut
+     */
+    class ChannelOut {
+
+    public:
+
+        /**
+         * Construct a ChannelOut
+         * @param[in] ncv7751 Parent ncv7751 instance
+         * @param[in] num Channel number (1 through 12)
+         *
+         * @note the preferred method create a ChannelOut is
+         * to use ::channel on the given NCV7751 instance
+         */
+        ChannelOut(NCV7751& ncv7751, int num);
+
+        /** Set the output off or on, specified as 0 or 1 (int), respectively
+         *
+         *  @param value An integer specifying the pin output value,
+         *      0 for logical 0, 1 (or any other non-zero value) for logical 1
+         */
+        void write(int value);
+
+        /** Return the output setting, represented as 0 or 1 (int)
+         *
+         *  @returns
+         *    an integer representing the output setting of the pin,
+         *    0 for logical 0, 1 for logical 1
+         */
+        int read();
+
+        /**
+         * Gets the fault condition of the channel
+         *
+         * @note this does not check the PWM input status bits
+         *
+         * @note If a fault is reported on a channel, you
+         * must typically disable the channel and then re-enable
+         * the channel to reset the fault condition. This will only
+         * work if the cause of the fault is also removed.
+         */
+        fault_condition_t get_fault(void);
+
+        /**
+         * Enables the open load diagnostics on this channel
+         */
+        void enable_open_load_diag(void);
+
+        /**
+         * Disables the open load diagnostics on this channel
+         */
+        void disable_open_load_diag(void);
+
+        /**
+         * Checks if open load diagnostics are enabled on this channel
+         */
+        bool open_load_diag_enabled(void);
+
+        /**
+         * Set the output to on
+         */
+        inline void on(void) {
+            write(1);
+        }
+
+        /**
+         * Set the output to off
+         */
+        inline void off(void) {
+            write(0);
+        }
+
+        /**
+         * Returns true if current state of channel is on
+         */
+        inline bool is_on(void) {
+            return (read() == 1);
+        }
+
+        /**
+         * Returns true if current state of channel is off
+         */
+        inline bool is_off(void) {
+            return (read() == 0);
+        }
+
+        /** A shorthand for write()
+         * \sa ChannelOut::write()
+         * @code
+         *      ChannelOut led(LED1);
+         *      led = 1;   // Equivalent to led.write(1)
+         * @endcode
+         */
+        ChannelOut &operator=(int value) {
+            // Underlying write is thread safe
+            write(value);
+            return *this;
+        }
+
+        /** A shorthand for write() using the assignment operator which copies the
+         * state from the DigitalOut argument.
+         * \sa DigitalOut::write()
+         */
+        ChannelOut &operator=(ChannelOut &rhs) {
+            write(rhs.read());
+            return *this;
+        }
+
+        /** A shorthand for read()
+         * \sa DigitalOut::read()
+         */
+        operator int() {
+            // Underlying call is thread safe
+            return read();
+        }
+
+    protected:
+        NCV7751& _parent; /** Parent NCV7751 of this channel object */
+        int _num; /** Channel number of this object (1-12) */
+
+    };
+
+public:
+
+    /** Allow ChannelOut to access internal members */
+    friend class ChannelOut;
+
+    /**
+     * Instantiate an NCV7751 driver
+     * @param[in] spi SPI bus instance to use for communication (16-bit format!)
+     * @param[in] csb1 Chip select "bar" 1
+     * @param[in] csb2 Chip select "bar" 2
+     * @param[in] global_en Global enable pin, defaults to NC (unused)
+     *
+     * @note The SPI bus instance used must be configured for 16-bit format
+     * to work properly!
+     */
+    NCV7751(mbed::SPI& spi, PinName csb1, PinName csb2, PinName global_en = NC);
+
+    /**
+     * Destructor
+     */
+    ~NCV7751(void);
+
+    /**
+     * Globally enable (if global_en != NC)
+     */
+    void enable(void);
+
+    /**
+     * Globally disable (if global_en != NC)
+     */
+    void disable(void);
+
+    /**
+     * Convenience function to create a ChannelOut object for a given
+     * channel
+     *
+     * @param[in] num Desired channel number. Allowed values: 1 thru 12
+     * @retval channel Reference to channel
+     */
+    ChannelOut channel(int num);
+
+    /**
+     * Batch writes channel settings to the NCV7751
+     *
+     * If your application requires closely-timed output transitions,
+     * this function ensures the output states are updated in the same
+     * SPI transaction.
+     *
+     * This is useful if, for example, you are using two outputs in
+     * parallel to achieve a higher current capacity
+     *
+     * @param[in] channel_bits Each desired channel state is represented by
+     * a bit in this number. The bit corresponds to channel (bit_pos) + 1.
+     * (eg: bit 0 represents the desired state of channel 1, 1 = on, 0 = off)
+     *
+     * @param[in] open_load_en Similar to channel bits, each bit in this
+     * number represents whether open-load diagnostics are desired on
+     * the given channel. 0 = not enabled, 1 = enabled. Defaults to disabled.
+     *
+     * @retval diag_bits 32-bit output from NCV7608 representing the diagnostics
+     * state of each channel. If you are using the ChannelOut API there are
+     * convenience functions to interpret this information for you.
+     */
+    uint32_t batch_write(uint16_t channel_bits, uint16_t ol_bits = 0x0);
+
+protected:
+
+    /**
+     * Writes a new 32-bit state to the NCV7751
+     * @param[in] state New state to write
+     * @retval diag_bits See ::batch_write
+     */
+    uint32_t write_state(uint32_t state);
+
+    /**
+     * Returns the cached channel state
+     */
+    uint32_t get_cached_state(void) {
+        return _cached_state;
+    }
+
+    /**
+     * Returns the cached diagnostics bits
+     */
+    uint32_t get_cached_diag(void) {
+        return _cached_diag;
+    }
+
+protected:
+
+    mbed::SPI& _spi;
+    mbed::DigitalOut _csb1;
+    mbed::DigitalOut _csb2;
+    mbed::DigitalOut* _global_en;
+
+    uint32_t _cached_state; /** Cached channel on/off state bits */
+    uint32_t _cached_diag;  /** Cached diagnostics bits */
+
+    PlatformMutex _mutex;
+
+};
+
+}
+
+
+
+#endif /* EP_OC_MCU_DEVICES_NCV7751_NCV7751_H_ */

--- a/devices/NCV7751/NCV7751.h
+++ b/devices/NCV7751/NCV7751.h
@@ -227,26 +227,32 @@ public:
      * number represents whether open-load diagnostics are desired on
      * the given channel. 0 = not enabled, 1 = enabled. Defaults to disabled.
      *
-     * @retval diag_bits 32-bit output from NCV7608 representing the diagnostics
+     * @retval diag_bits 32-bit output from NCV7751 representing the diagnostics
      * state of each channel. If you are using the ChannelOut API there are
      * convenience functions to interpret this information for you.
      */
-    uint32_t batch_write(uint16_t channel_bits, uint16_t ol_bits = 0x0);
+    uint32_t write_state(uint16_t channel_bits, uint16_t ol_bits = 0x0);
 
 protected:
 
     /**
-     * Writes a new 32-bit state to the NCV7751
-     * @param[in] state New state to write
-     * @retval diag_bits See ::batch_write
+     * Sync the cached state and diagnostic bits
+     * @retval diag_bits Sync'd diagnostic bits
      */
-    uint32_t write_state(uint32_t state);
+    uint32_t sync(void);
 
     /**
-     * Returns the cached channel state
+     * Returns the channel on/off bits
      */
-    uint32_t get_cached_state(void) {
-        return _cached_state;
+    uint16_t get_channel_bits(void) {
+        return _channel_bits;
+    }
+
+    /**
+     * Returns the open-load enable/disable bits
+     */
+    uint16_t get_ol_bits(void) {
+        return _ol_bits;
     }
 
     /**
@@ -263,7 +269,9 @@ protected:
     mbed::DigitalOut _csb2;
     mbed::DigitalOut* _global_en;
 
-    uint32_t _cached_state; /** Cached channel on/off state bits */
+    uint16_t _channel_bits; /** Channel on/off bits */
+    uint16_t _ol_bits;      /** Open-load enable/disable bits */
+
     uint32_t _cached_diag;  /** Cached diagnostics bits */
 
     PlatformMutex _mutex;

--- a/devices/NCV7751/NCV7751.h
+++ b/devices/NCV7751/NCV7751.h
@@ -41,8 +41,7 @@ public:
     typedef enum {
         NO_FAULT,           /** No fault condition */
         OPEN_LOAD,          /** Open load condition exists on channel */
-        OVER_LOAD,          /** Over-load condition exists on channel */
-        OVER_TEMPERATURE,   /** Over temperature fault */
+        OVER_LOAD,          /** Over-load/Over-temperature condition exists on channel */
     } fault_condition_t;
 
     /**


### PR DESCRIPTION
The NCV7751 is an automotive-grade, 12-channel, low-side load driver chip with SPI communication and integrated diagnostics functionality.

This PR adds support for interacting with this chip over a 16-bit SPI bus.