### PR TITLE
Added constructor to NCV7608 using DigitalOut

### DIFF
--- a/devices/NCV7608/NCV7608.cpp
+++ b/devices/NCV7608/NCV7608.cpp
@@ -31,27 +31,34 @@
 using namespace ep;
 
 NCV7608::NCV7608(mbed::SPI& spi, PinName csb, PinName global_en) :
-        _spi(spi), _cs(nullptr), _global_en(nullptr), _cached_state(0), _cached_diag(
-                0) {
+        _spi(spi), _cs(nullptr), _global_en(nullptr), _cached_state(0),
+        _cached_diag(0), _owns_csb(false), _owns_gen(false) {
 
     // Instantiate optional control outputs
     if (csb != NC) {
         _cs = new mbed::DigitalOut(csb, 1);
+        _owns_csb = true;
     }
 
     if (global_en != NC) {
         // Disabled by default
         _global_en = new mbed::DigitalOut(global_en, 0);
+        _owns_csb = true;
     }
+}
+
+NCV7608::NCV7608(mbed::SPI& spi, mbed::DigitalOut* csb,
+        mbed::DigitalOut* global_en) : _spi(spi), _cs(csb), _global_en(global_en),
+                _cached_state(0), _cached_diag(0), _owns_csb(false), _owns_gen(false) {
 }
 
 NCV7608::~NCV7608(void) {
     // Clean up any dynamically allocated members
-    if (_cs != nullptr) {
+    if (_cs != nullptr && _owns_csb) {
         delete _cs;
     }
 
-    if (_global_en != nullptr) {
+    if (_global_en != nullptr && _owns_gen) {
         delete _global_en;
     }
 }

--- a/devices/NCV7608/NCV7608.h
+++ b/devices/NCV7608/NCV7608.h
@@ -205,6 +205,18 @@ public:
     NCV7608(mbed::SPI& spi, PinName csb = NC, PinName global_en = NC);
 
     /**
+     * Instantiate an NCV7608 driver
+     * @param[in] spi SPI bus instance to use for communication (16-bit format!)
+     * @param[in] csb Chip select "bar" DigitalOut object
+     * @param[in] global_en Global enable pin, DigitalOut object
+     *
+     * @note The SPI bus instance used must be configured for 16-bit format
+     * to work properly!
+     */
+    NCV7608(mbed::SPI& spi, mbed::DigitalOut* csb,
+            mbed::DigitalOut* global_en);
+
+    /**
      * Destructor
      */
     ~NCV7608(void);
@@ -297,6 +309,9 @@ protected:
     uint16_t _cached_diag;  /** Cached diagnostics bits */
 
     PlatformMutex _mutex;
+
+    bool _owns_csb;  /** Flag if this object owns/created the CSB output object */
+    bool _owns_gen;  /** Flag if this object owns/created the global en output object */
 
 };
 


### PR DESCRIPTION
In some cases, like when using an IO Expander, the CSB and Global EN outputs may not be available as raw "PinName" types in the user application.

This PR adds an alternate constructor to the NCV7608 class that allows instantiation using an existing `DigitalOut` (or subclass) instance. 

This approach should be made consistent elsewhere, as appropriate (ie: NCV7751 driver).