### PR TITLE
Ignore ResistorDivider and ThermistorNTC

### DIFF
--- a/devices/.mbedignore
+++ b/devices/.mbedignore
@@ -1,0 +1,2 @@
+ResistorDivider/*
+ThermistorNTC/*


### PR DESCRIPTION
These APIs must be ignored to properly build with mainstream mbed-os until (and if) ARMmbed/mbed-os#12471 is pulled in...