### PR TITLE
Ignore GattSubscriber until it is updated to function with new BLE API

### DIFF
--- a/features/FEATURE_BLE/.mbedignore
+++ b/features/FEATURE_BLE/.mbedignore
@@ -1,0 +1,2 @@
+GattSubscriber.h
+GattSubscriber.cpp


### PR DESCRIPTION
The GattSubscriber API currently causes compilation issues because it uses deprecated (now removed) BLE API calls in Mbed-OS.

The implementation must be updated to only use current BLE API calls. This PR ignores the GattSubscriber API until it is fixed.