### PR TITLE
Replaced wait_ms calls

### DIFF
--- a/devices/BME680/BME680.cpp
+++ b/devices/BME680/BME680.cpp
@@ -24,7 +24,7 @@
 #include "BME680.h"
 #include <math.h>
 #include "platform/mbed_debug.h"
-#include "platform/mbed_wait_api.h"
+#include "rtos/ThisThread.h"
 
 static mbed::I2C* bme680_i2c;
 
@@ -358,5 +358,5 @@ int8_t BME680::i2c_write(uint8_t dev_id, uint8_t reg_addr, uint8_t *reg_data, ui
 
 void BME680::delay_msec(uint32_t ms) {
     debug(" * wait %d ms ... \r\n", ms);
-    wait_ms(ms);
+    rtos::ThisThread::sleep_for(std::chrono::milliseconds(ms));
 }

--- a/devices/ST/VL53L0X/VL53L0X.h
+++ b/devices/ST/VL53L0X/VL53L0X.h
@@ -49,7 +49,8 @@
 #include "VL53L0X_def.h"
 #include "VL53L0X_platform.h"
 #include "Stmpe1600.h"
-
+#include "mbed_wait_api.h"
+#include "rtos/ThisThread.h"
 
 /**
  * The device model ID
@@ -60,7 +61,7 @@
 #define STATUS_OK              0x00
 #define STATUS_FAIL            0x01
 
-#define VL53L0X_OsDelay(...) wait_ms(2) // 2 msec delay. can also use wait(float secs)/wait_us(int)
+#define VL53L0X_OsDelay(...) wait_us(2000) // 2 msec delay. can also use wait(float secs)/wait_us(int)
 
 #ifdef USE_EMPTY_STRING
 #define  VL53L0X_STRING_DEVICE_INFO_NAME                             ""
@@ -328,7 +329,8 @@ public:
     /* turns on the sensor */
     void VL53L0X_on(void)
     {
-        wait_ms(10);
+        
+        rtos::ThisThread::sleep_for(std::chrono::milliseconds(10));
     }
 
     /**
@@ -338,7 +340,7 @@ public:
     /* turns off the sensor */
     void VL53L0X_off(void)
     {
-        wait_ms(10);
+        rtos::ThisThread::sleep_for(std::chrono::milliseconds(10));
     }
 
     /**

--- a/examples/drivers/EasyScale-example/main.cpp
+++ b/examples/drivers/EasyScale-example/main.cpp
@@ -26,7 +26,7 @@
 
 #include "devices/EasyScale.h"
 
-#include "platform/mbed_wait_api.h"
+#include "rtos/ThisThread.h"
 
 #define EASYSCALE_CTRL_PIN P0_3
 
@@ -56,7 +56,7 @@ int main(void)
 			if(brightness == 0)
 				going_up = true;
 		}
-		wait_ms(250);
+                rtos::ThisThread::sleep_for(250ms);
 	}
 }
 


### PR DESCRIPTION
Replaces calls to deprecated (now removed) `wait_ms` function throughout ep-oc-mcu. Updated to use chrono API to maintain future compatibility with Mbed sleep API.

Fixes #20 