### PR TITLE
Add SWO Debug Output Utility

### DIFF
--- a/utils/mbed_lib.json
+++ b/utils/mbed_lib.json
@@ -1,0 +1,9 @@
+{
+    "name": "ep-utils",
+    "config": {
+        "swo-debug-output": {
+            "help": "Use SWO as default debug output channel",
+            "value": false
+        }
+    }
+}

--- a/utils/swo_debug_retarget.cpp
+++ b/utils/swo_debug_retarget.cpp
@@ -21,10 +21,12 @@
  *
  */
 
+#if MBED_CONF_EP_UTILS_SWO_DEBUG_OUTPUT
+
+#if defined(DEVICE_ITM)
+
 #include "platform/mbed_retarget.h"
 #include "drivers/SerialWireOutput.h"
-
-#if MBED_CONF_EP_UTILS_SWO_DEBUG_OUTPUT
 
 /**
  * Retarget the Mbed stdio stream to SWO
@@ -35,6 +37,12 @@ mbed::FileHandle *mbed::mbed_target_override_console(int fd)
     return &swo;
 }
 
-#endif
+#else
+#warning This target does not support SWO output but ep-utils.swo-debug-output is enabled!
+
+#endif /** defined(DEVICE_ITM) */
+#endif /** MBED_CONF_EP_UTILS_SWO_DEBUG_OUTPUT */
+
+
 
 

--- a/utils/swo_debug_retarget.cpp
+++ b/utils/swo_debug_retarget.cpp
@@ -1,0 +1,40 @@
+/**
+ * ep-oc-mcu
+ * Embedded Planet Open Core for Microcontrollers
+ *
+ * Built with ARM Mbed-OS
+ *
+ * Copyright (c) 2019-2020 Embedded Planet, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "platform/mbed_retarget.h"
+#include "drivers/SerialWireOutput.h"
+
+#if MBED_CONF_EP_UTILS_SWO_DEBUG_OUTPUT
+
+/**
+ * Retarget the Mbed stdio stream to SWO
+ */
+mbed::FileHandle *mbed::mbed_target_override_console(int fd)
+{
+    static mbed::SerialWireOutput swo;
+    return &swo;
+}
+
+#endif
+
+


### PR DESCRIPTION
In some cases, such as with constrained IO, it may be necessary to use the default debug UART pins for some other function. This PR adds a simple framework for redirecting debug UART output to the dedicated SWO interface on supported targets.

The user can then see the output stream with eg: a JLink and using the `swoview` command.

To enable defaulting to SWO output, configure the following in your `mbed_app.json`:

```
"ep-utils.swo-debug-output": true
```

Note: this PR does not currently allow for accessing the input stream of SWO (I think it allows input, too?)