### PR TITLE
Updated BME680 driver to prevent errors during baremetal builds

### DIFF
--- a/devices/BME680/BME680_BSEC.cpp
+++ b/devices/BME680/BME680_BSEC.cpp
@@ -21,6 +21,8 @@
  *
  */
 
+#if defined(MBED_CONF_RTOS_PRESENT) // For baremetal builds
+
 #include "BME680_BSEC.h"
 #include "rtos/Mutex.h"
 #include "rtos/ThisThread.h"
@@ -446,3 +448,5 @@ void BME680_BSEC::set_iaq_accuracy(uint8_t new_iaq_accuracy)
 {
     iaq_accuracy = new_iaq_accuracy;
 }
+
+#endif //defined(MBED_CONF_RTOS_PRESENT)

--- a/devices/BME680/BME680_BSEC.h
+++ b/devices/BME680/BME680_BSEC.h
@@ -24,6 +24,8 @@
 #ifndef BME680_H
 #define BME680_H
 
+#if defined(MBED_CONF_RTOS_PRESENT) // For baremetal builds
+
 #include "bme680_driver.h"
 #include "bsec_integration.h"
 #include "events/EventQueue.h"
@@ -117,5 +119,7 @@ private:
     BME680_BSEC(BME680_BSEC const&){};
     static BME680_BSEC* instance;
 };
+
+#endif // defined(MBED_CONF_RTOS_PRESENT)
 
 #endif


### PR DESCRIPTION
The BME680_BSEC driver includes `rtos/Thread.h` and causes Baremetal builds to fail. This change introduces a preprocessor that will ignore the BME680_BSEC drivers if the build is using the baremetal profile.