### PR TITLE
Created SerialCOBS wrapper class to encode/decode streams in COBS format

### DIFF
--- a/extensions/SerialCOBS/SerialCOBS.cpp
+++ b/extensions/SerialCOBS/SerialCOBS.cpp
@@ -1,0 +1,163 @@
+/**
+ * ep-oc-mcu
+ * Embedded Planet Open Core for Microcontrollers
+ *
+ * Built with ARM Mbed-OS
+ *
+ * Copyright (c) 2019-2020 Embedded Planet, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "SerialCOBS.h"
+
+#include "platform/ScopedLock.h"
+#include "platform/mbed_thread.h"
+
+#include "cobsr.h"
+
+SerialCOBS::SerialCOBS(mbed::FileHandle& fh) : _fh(fh), _staging_index(0) {
+}
+
+ssize_t SerialCOBS::write(const void* buffer, size_t size) {
+
+    char txbuf[MBED_CONF_SERIALCOBS_TXBUF_SIZE];
+
+    /** Mutex will be unlocked at the end of this variable's scope */
+    mbed::ScopedLock<PlatformMutex> lock(_mutex);
+
+    /** Encode the buffer with COBS */
+    cobsr_encode_result result = cobsr_encode(txbuf,
+            MBED_CONF_SERIALCOBS_TXBUF_SIZE-1, buffer, size);
+
+    if(result.status == COBSR_ENCODE_NULL_POINTER) {
+        return -EINVAL;
+    }
+
+    if(result.status == COBSR_ENCODE_OUT_BUFFER_OVERFLOW) {
+        return -EOVERFLOW;
+    }
+
+    /** Set the delimiter */
+    txbuf[result.out_len] = '\0';
+
+    /** Pass on to given file handle */
+    size_t total_size = result.out_len+1;
+    size_t write_result = _fh.write(txbuf, total_size);
+
+    /** Propagate error codes up */
+    if(write_result != total_size) {
+        return write_result;
+    }
+
+    // Return the original size expected by the caller
+    return size;
+}
+
+ssize_t SerialCOBS::read(void* buffer, size_t size) {
+
+    size_t data_read = 0;
+
+    char *ptr = static_cast<char *>(buffer);
+
+    if (size == 0) {
+        return 0;
+    }
+
+    _mutex.lock();
+
+    // If empty, attempt to read and decode underlying file handle
+    if(_output_buf.empty()) {
+        read_and_decode();
+    }
+
+    while (_output_buf.empty()) {
+        if (!_fh.is_blocking()) {
+            _mutex.unlock();
+            return -EAGAIN;
+        }
+        _mutex.unlock();
+        thread_sleep_for(1);
+        _mutex.lock();
+        read_and_decode();
+    }
+
+    while (data_read < size && !_output_buf.empty()) {
+        _output_buf.pop(*ptr++);
+        data_read++;
+    }
+
+    _mutex.unlock();
+
+    return data_read;
+}
+
+void SerialCOBS::read_and_decode() {
+
+    /** Read underlying file handle into staging buffer */
+    char rx_byte;
+    _fh.read(&rx_byte, 1);
+
+    // If this is a 0-byte delimeter, stop here and decode
+    if(rx_byte == '\0') {
+        char decode_buf[MBED_CONF_SERIALCOBS_RXBUF_SIZE];
+        cobsr_decode_result result = cobsr_decode(
+                decode_buf, MBED_CONF_SERIALCOBS_RXBUF_SIZE,
+                _staging_buf, _staging_index);
+
+        if(result.status != COBSR_DECODE_OK) {
+            _staging_index = 0;
+            return;
+        }
+
+        // Push the decoded buffer to the output buffer
+        for(unsigned int i = 0; i < result.out_len; i++) {
+            _output_buf.push(decode_buf[i]);
+        }
+
+        // Reset index
+        _staging_index = 0;
+
+    } else {
+        // Otherwise, just add it into the staging buffer
+        _staging_buf[_staging_index++] = rx_byte;
+        if(_staging_index > MBED_CONF_SERIALCOBS_RXBUF_SIZE) {
+            // Overflow! TODO - trace
+            _staging_index = 0;
+        }
+    }
+}
+
+//short SerialCOBS::poll(short events) const {
+//
+//    short revents = 0;
+//    // Check the Circular Buffer if space available for writing out
+//
+//    if(!_output_buf.empty()) {
+//        revents |= POLLIN;
+//    }
+//
+//    // POLLHUP and POLLOUT, get from underlying file handle
+////    short underlying_events = _fh.poll(events);
+////    // Clear the POLLIN flag
+////    underlying_events &= ~(POLLIN);
+////    // OR underlying events in
+////    revents |= underlying_events;
+//    // mask with given mask
+//    revents &= events;
+//
+//    return revents;
+//
+//}

--- a/extensions/SerialCOBS/SerialCOBS.h
+++ b/extensions/SerialCOBS/SerialCOBS.h
@@ -1,0 +1,167 @@
+/**
+ * ep-oc-mcu
+ * Embedded Planet Open Core for Microcontrollers
+ *
+ * Built with ARM Mbed-OS
+ *
+ * Copyright (c) 2019-2020 Embedded Planet, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef SERIALCOBS_H_
+#define SERIALCOBS_H_
+
+#include "platform/FileHandle.h"
+#include "platform/PlatformMutex.h"
+#include "platform/CircularBuffer.h"
+
+#ifndef MBED_CONF_SERIALCOBS_RXBUF_SIZE
+#define MBED_CONF_SERIALCOBS_RXBUF_SIZE  256
+#endif
+
+#ifndef MBED_CONF_SERIALCOBS_TXBUF_SIZE
+#define MBED_CONF_SERIALCOBS_TXBUF_SIZE  256
+#endif
+
+/**
+ * Encodes and decodes a given serial stream using COBS
+ */
+class SerialCOBS : public mbed::FileHandle
+{
+
+public:
+
+    /**
+     * Instantiate a SerialCOBS instance
+     * @param[in] fh FileHandle to wrap with COBS encoding/decoding
+     */
+    SerialCOBS(mbed::FileHandle& fh);
+
+    ssize_t write(const void *buffer, size_t size) override;
+
+    ssize_t read(void *buffer, size_t size) override;
+
+    off_t seek(off_t offset, int whence = SEEK_SET) override
+    {
+        /* Seeking is not support by this file handler */
+        return _fh.seek(offset, whence);
+    }
+
+    off_t size() override
+    {
+        /* Size is not defined for this file handle */
+        return _fh.size();
+    }
+
+    int isatty() override
+    {
+        /* File handle is used for terminal output */
+        return _fh.isatty();
+    }
+
+    int close() override
+    {
+        return _fh.close();
+    }
+
+    int sync() override
+    {
+        return _fh.sync();
+    }
+
+    off_t tell() override
+    {
+        return _fh.tell();
+    }
+
+    void rewind() override
+    {
+        return _fh.rewind();
+    }
+
+    int truncate(off_t length) override
+    {
+        return _fh.truncate(length);
+    }
+
+    int enable_input(bool enabled) override
+    {
+        return _fh.enable_input(enabled);
+    }
+
+    int enable_output(bool enabled) override
+    {
+        return _fh.enable_output(enabled);
+    }
+
+    short poll(short events) const override
+    {
+        return _fh.poll(events);
+    }
+
+    void sigio(mbed::Callback<void()> func) override
+    {
+        _fh.sigio(func);
+    }
+
+    /** Set blocking or non-blocking mode
+     *  The default is blocking.
+     *
+     *  @param blocking true for blocking mode, false for non-blocking mode.
+     */
+    int set_blocking(bool blocking) override
+    {
+        return _fh.set_blocking(blocking);
+    }
+
+    /** Check current blocking or non-blocking mode for file operations.
+     *
+     *  @return true for blocking mode, false for non-blocking mode.
+     */
+    bool is_blocking() const override
+    {
+        return _fh.is_blocking();
+    }
+
+protected:
+
+    void read_and_decode(void);
+
+protected:
+
+    /** Internal file handle that is wrapped with COBS encoding/decoding */
+    mbed::FileHandle& _fh;
+
+    /** Software serial buffers
+     *  By default buffer size is 256 for TX and 256 for RX. Configurable
+     *  through mbed_app.json
+     */
+
+    /** Staging buffer for reading in complete COBS-encoded packets */
+    char _staging_buf[MBED_CONF_SERIALCOBS_RXBUF_SIZE];
+
+    /** Staging buffer write index */
+    size_t _staging_index;
+
+    /** Output buffer to pass on decoded COBS packets */
+    mbed::CircularBuffer<char, MBED_CONF_SERIALCOBS_RXBUF_SIZE> _output_buf;
+
+    /** Mutex */
+    PlatformMutex _mutex;
+
+};
+
+#endif /* SERIALCOBS_H_ */

--- a/extensions/SerialCOBS/cobs-c.lib
+++ b/extensions/SerialCOBS/cobs-c.lib
@@ -1,0 +1,1 @@
+https://github.com/EmbeddedPlanet/cobs-c/#3a52ae1d8bd7f102e39655ad31fc7102c08027ab

--- a/extensions/SerialCOBS/mbed_lib.json
+++ b/extensions/SerialCOBS/mbed_lib.json
@@ -1,0 +1,7 @@
+{
+    "name": "serialcobs",
+    "config": {
+        "rxbuf-size": 256,
+        "txbuf-size": 256
+    }
+}


### PR DESCRIPTION
This class encodes/decodes streams using COBS-R. This format replaces null bytes in the data payload so that they may be used for packet delimiting. This is useful when transferring raw binary over a serial port, for example.

This class uses the [`cobs-c`](https://github.com/EmbeddedPlanet/cobs-c/) library, a lightweight, C-based COBS implementation.

Writes to a SerialCOBS class are automatically padded with the extra byte(s) required for COBS-R encoding using an internal, configurable-size buffer. 

Similarly, reads are internally buffered in a configurable-size buffer until a 0-byte is received. At this point, the collected bytes are decoded with the cobs-c library. If everything goes well, the decoded buffer is pushed onto a configurable-size CircularBuffer.

I have only tested this class with `set_blocking` set to `true`. I think it will work it in either case, may need to write some loopback tests though.