### PR TITLE
Implement provisions for backward compatibility with Mbed-OS-5.x

### DIFF
--- a/devices/BME680/BME680.cpp
+++ b/devices/BME680/BME680.cpp
@@ -22,8 +22,12 @@
  */
 
 #include "BME680.h"
-#include <math.h>
+
+#include <cmath>
+
 #include "platform/mbed_debug.h"
+#include "platform/mbed_version.h"
+
 #include "rtos/ThisThread.h"
 
 static mbed::I2C* bme680_i2c;
@@ -143,7 +147,7 @@ float BME680::getTemperature() {
 
     if (_tempEnabled) {
         temperature = data.temperature / 100.0;
-        debug("Temperature Raw Data %d \r\n", temperature);
+        debug("Temperature Raw Data %f \r\n", temperature);
     }
 
     return temperature;
@@ -158,7 +162,7 @@ float BME680::getHumidity() {
 
     if (_humEnabled) {
         humidity = data.humidity / 1000.0;
-        debug("Humidity Raw Data %d \r\n", humidity);
+        debug("Humidity Raw Data %f\r\n", humidity);
     }
 
     return humidity;
@@ -175,7 +179,7 @@ float BME680::getPressure() {
 
     if (_presEnabled) {
         pressure = data.pressure;
-        debug("Pressure Raw Data %d \r\n", pressure);
+        debug("Pressure Raw Data %f \r\n", pressure);
     }
 
     return pressure;
@@ -191,7 +195,7 @@ float BME680::getGasResistance() {
     if (_gasEnabled) {
         if (this->isGasHeatingSetupStable()) {
             gas_resistance = data.gas_resistance;
-            debug("Gas Resistance Raw Data %d \r\n", gas_resistance);
+            debug("Gas Resistance Raw Data %f \r\n", gas_resistance);
         } else {
             debug("Gas reading unstable \r\n");
         }
@@ -358,5 +362,9 @@ int8_t BME680::i2c_write(uint8_t dev_id, uint8_t reg_addr, uint8_t *reg_data, ui
 
 void BME680::delay_msec(uint32_t ms) {
     debug(" * wait %d ms ... \r\n", ms);
+#if MBED_MAJOR_VERSION == 5
+    rtos::ThisThread::sleep_for(ms);
+#else
     rtos::ThisThread::sleep_for(std::chrono::milliseconds(ms));
+#endif
 }

--- a/devices/ResistorDivider/ResistorDivider.cpp
+++ b/devices/ResistorDivider/ResistorDivider.cpp
@@ -41,7 +41,11 @@ float ResistorDivider::get_R_pu_ohms(void) {
         return r_pu;
     } else {
         // Calculate pu
+#if MBED_MAJOR_VERSION == 5
+        return (r_pd * ((vin_volts / (adc_in.read() * MBED_CONF_TARGET_DEFAULT_ADC_VREF))));
+#else
         return (r_pd * ((vin_volts / adc_in.read_voltage()) - 1.0f));
+#endif
     }
 }
 
@@ -51,7 +55,11 @@ float ResistorDivider::get_R_pd_ohms(void) {
         return r_pd;
     } else {
         // Calculate pd
+#if MBED_MAJOR_VERSION == 5
+        return (r_pu * (1.0f / ((vin_volts / (adc_in.read() * MBED_CONF_TARGET_DEFAULT_ADC_VREF)) - 1.0f )));
+#else
         return (r_pu * (1.0f / ((vin_volts / adc_in.read_voltage()) - 1.0f)));
+#endif
     }
 }
 
@@ -61,6 +69,10 @@ float ResistorDivider::get_Vin_volts(void) {
         return vin_volts;
     } else {
         // Calculate vin_volts
+#if MBED_MAJOR_VERSION == 5
+        return (((r_pu + r_pd) / r_pd) * (adc_in.read() * MBED_CONF_TARGET_DEFAULT_ADC_VREF));
+#else
         return (((r_pu + r_pd) / r_pd) * adc_in.read_voltage());
+#endif
     }
 }

--- a/devices/ResistorDivider/ResistorDivider.h
+++ b/devices/ResistorDivider/ResistorDivider.h
@@ -24,8 +24,36 @@
 #ifndef EP_OC_MCU_DEVICES_RESISTORDIVIDER_RESISTORDIVIDER_H_
 #define EP_OC_MCU_DEVICES_RESISTORDIVIDER_RESISTORDIVIDER_H_
 
+#include "platform/mbed_version.h"
+
 /** The target must have an ADC to use this resistor divider class */
 #if DEVICE_ANALOGIN
+
+/**
+ * The adc reference voltage configuration was not introduced until 
+ * Mbed-OS 6, so we must retarget this macro to maintain compatibility
+ * with Mbed-OS 5.
+ *
+ * This setting sets the voltage used to scale an ADC reading
+ * Defaults to 3.3V
+ * May be reconfigured by adding a the following to your mbed_app.json:
+ * 
+ * "config": {
+ *  "default-adc-vref": {
+ *   "value": 5.0f
+ *  }
+ * }
+ *
+ */
+ #if MBED_MAJOR_VERSION == 5
+    #ifndef MBED_CONF_TARGET_DEFAULT_ADC_VREF
+        #ifndef MBED_CONF_APP_DEFAULT_ADC_VREF
+            #define MBED_CONF_TARGET_DEFAULT_ADC_VREF 3.3f
+        #else
+            #define MBED_CONF_TARGET_DEFAULT_ADC_VREF MBED_CONF_APP_DEFAULT_ADC_VREF 
+        #endif
+    #endif 
+ #endif
 
 #include "drivers/AnalogIn.h"
 

--- a/devices/ST/VL53L0X/VL53L0X.h
+++ b/devices/ST/VL53L0X/VL53L0X.h
@@ -51,6 +51,7 @@
 #include "Stmpe1600.h"
 #include "mbed_wait_api.h"
 #include "rtos/ThisThread.h"
+#include "platform/mbed_version.h"
 
 /**
  * The device model ID
@@ -329,8 +330,11 @@ public:
     /* turns on the sensor */
     void VL53L0X_on(void)
     {
-        
+#if MBED_MAJOR_VERSION == 5
+        rtos::ThisThread::sleep_for(10);
+#else
         rtos::ThisThread::sleep_for(std::chrono::milliseconds(10));
+#endif
     }
 
     /**
@@ -340,7 +344,11 @@ public:
     /* turns off the sensor */
     void VL53L0X_off(void)
     {
+#if MBED_MAJOR_VERSION == 5
+        rtos::ThisThread::sleep_for(10);
+#else
         rtos::ThisThread::sleep_for(std::chrono::milliseconds(10));
+#endif
     }
 
     /**


### PR DESCRIPTION
Changes to BME680, VL53L0X, and ResistorDivider to maintain compatibility with Mbed-OS 5.

I tested our [mbed-os-example-pelion](https://github.com/EmbeddedPlanet/mbed-os-example-pelion) demo and was able to build with Mbed Studio on Linux w/ both GCC and ARMC6.

Resolves #31 
Resolves #32 

@trowbridgec 