### PR TITLE
ThermistorNTC and ResistorDivider Refactor

### DIFF
--- a/devices/ResistorDivider/ResistorDivider.cpp
+++ b/devices/ResistorDivider/ResistorDivider.cpp
@@ -27,7 +27,7 @@
 
 using namespace ep;
 
-ResistorDivider::ResistorDivider(mbed::AnalogIn& adc_in, float r_pd, float r_pu,
+ResistorDivider::ResistorDivider(mbed::AnalogIn* adc_in, float r_pd, float r_pu,
         float vin_volts) : adc_in(adc_in), r_pu(r_pu), r_pd(r_pd), vin_volts(vin_volts) {
 
     /** Exactly 2 of the given parameters must be > 0.0f (ie: they are known/fixed parameters) */
@@ -44,7 +44,7 @@ float ResistorDivider::get_R_pu_ohms(void) {
 #if MBED_MAJOR_VERSION == 5
         return (r_pd * ((vin_volts / (adc_in.read() * MBED_CONF_TARGET_DEFAULT_ADC_VREF))));
 #else
-        return (r_pd * ((vin_volts / adc_in.read_voltage()) - 1.0f));
+        return (r_pd * ((vin_volts / adc_in->read_voltage()) - 1.0f));
 #endif
     }
 }
@@ -58,7 +58,7 @@ float ResistorDivider::get_R_pd_ohms(void) {
 #if MBED_MAJOR_VERSION == 5
         return (r_pu * (1.0f / ((vin_volts / (adc_in.read() * MBED_CONF_TARGET_DEFAULT_ADC_VREF)) - 1.0f )));
 #else
-        return (r_pu * (1.0f / ((vin_volts / adc_in.read_voltage()) - 1.0f)));
+        return (r_pu * (1.0f / ((vin_volts / adc_in->read_voltage()) - 1.0f)));
 #endif
     }
 }
@@ -72,7 +72,7 @@ float ResistorDivider::get_Vin_volts(void) {
 #if MBED_MAJOR_VERSION == 5
         return (((r_pu + r_pd) / r_pd) * (adc_in.read() * MBED_CONF_TARGET_DEFAULT_ADC_VREF));
 #else
-        return (((r_pu + r_pd) / r_pd) * adc_in.read_voltage());
+        return (((r_pu + r_pd) / r_pd) * adc_in->read_voltage());
 #endif
     }
 }

--- a/devices/ResistorDivider/ResistorDivider.h
+++ b/devices/ResistorDivider/ResistorDivider.h
@@ -116,7 +116,7 @@ namespace ep
          * will assert at runtime!
          *
          */
-        ResistorDivider(mbed::AnalogIn& adc_in, float r_pd,
+        ResistorDivider(mbed::AnalogIn* adc_in, float r_pd,
                 float r_pu = UnknownVal, float vin_volts = MBED_CONF_TARGET_DEFAULT_ADC_VREF);
 
         /**
@@ -145,7 +145,7 @@ namespace ep
 
     protected:
 
-        mbed::AnalogIn& adc_in; /** AnalogIn object used to take measurements of Vout with */
+        mbed::AnalogIn* adc_in; /** AnalogIn object used to take measurements of Vout with */
 
         float r_pu;         /** Given value of Rpu in the divider circuit (0.0f if unknown) */
         float r_pd;         /** Given value of Rpd in the divider circuit (0.0f if unknown) */

--- a/devices/ResistorDivider/ResistorDivider.h
+++ b/devices/ResistorDivider/ResistorDivider.h
@@ -36,7 +36,7 @@
  *
  * This setting sets the voltage used to scale an ADC reading
  * Defaults to 3.3V
- * May be reconfigured by adding a the following to your mbed_app.json:
+ * May be reconfigured by adding the following to your mbed_app.json:
  * 
  * "config": {
  *  "default-adc-vref": {

--- a/devices/ThermistorNTC/ThermistorNTC.cpp
+++ b/devices/ThermistorNTC/ThermistorNTC.cpp
@@ -33,16 +33,14 @@
 
 using namespace ep;
 
-ThermistorNTC::ThermistorNTC(ResistorDivider& r_div, float r_fixed,
-        ValueMapping* map, bool ntc_is_pull_up) : r_div(r_div),
-        r_to_t_map(map), beta_val(0.0f), r_fixed_ohms(r_fixed),
-        r_room_temp_ohms(0.0f), ntc_is_pull_up(ntc_is_pull_up) {
+ThermistorNTC::ThermistorNTC(ResistorDivider* r_div, ValueMapping* map, bool ntc_is_pull_up) : r_div(r_div),
+        r_to_t_map(map), beta_val(0.0f), r_room_temp_ohms(0.0f), ntc_is_pull_up(ntc_is_pull_up) {
 }
 
-ThermistorNTC::ThermistorNTC(ResistorDivider& r_div, float r_fixed, float beta,
+ThermistorNTC::ThermistorNTC(ResistorDivider* r_div, float beta,
         float r_room_temp, bool ntc_is_pull_up) : r_div(r_div),
-        r_to_t_map(NULL), beta_val(beta), r_fixed_ohms(r_fixed),
-        r_room_temp_ohms(r_room_temp), ntc_is_pull_up(ntc_is_pull_up) {
+        r_to_t_map(NULL), beta_val(beta), r_room_temp_ohms(r_room_temp),
+        ntc_is_pull_up(ntc_is_pull_up) {
 }
 
 float ThermistorNTC::get_temperature(void) {
@@ -50,9 +48,9 @@ float ThermistorNTC::get_temperature(void) {
     // Get the thermistor's resistance
     float r_thermistor;
     if(ntc_is_pull_up) {
-        r_thermistor = r_div.get_R_pu_ohms();
+        r_thermistor = r_div->get_R_pu_ohms();
     } else {
-        r_thermistor = r_div.get_R_pd_ohms();
+        r_thermistor = r_div->get_R_pd_ohms();
     }
 
     // If a table was given in the constructor, use the lookup table method

--- a/devices/ThermistorNTC/ThermistorNTC.h
+++ b/devices/ThermistorNTC/ThermistorNTC.h
@@ -41,7 +41,7 @@ namespace ep
      * Class representing an NTC thermistor
      *
      * It allows you to read a relative temperature using a resistor divider consisting
-     * of a fixed resistor (R_fixed) and a thermistor that's resistance varies with temperature.
+     * of a fixed resistor (R_fixed) and a thermistor which has a resistance that varies with temperature.
      *
      * Example Circuit Diagram:
      *
@@ -70,8 +70,8 @@ namespace ep
      *                     -
      *
      * The NTC thermistor may be either the pull-down or pull-up resistor in the
-     * divider circuit. The API assumes it is the pull-up by default. See the constructor
-     * for more information.
+     * divider circuit. This API assumes the NTC is a pull-up resistor by default. See the
+     * constructor API documentation for more information.
      *
      * Typically R_fixed is selected to be equal to R_NTC @ room temperature (25.0C)
      *
@@ -82,10 +82,13 @@ namespace ep
      * Example:
      * @code
      * #include "ThermistorNTC.h"
-     * #include "mbed_wait_api.h"
+     * #include "rtos/ThisThread.h"
      * #include "ge1923.h"
+     * #include <chrono>
      *
      * #define NTC_ADC_PIN A0
+     *
+     * using namespace std::chrono;
      *
      * ep::ThermistorNTC ntc(NTC_ADC_PIN, 10000.0f, 3957.0f, 10000.0f);
      *
@@ -98,7 +101,7 @@ namespace ep
      * int main(void) {
      *     while(true) {
      *         printf("temperature: %.2fC\r\n", ntc.get_temperature());
-     *         wait_us(1000000);
+     *         rtos::ThisThread::sleep_for(1s);
      *     }
      * }
      * @endcode
@@ -112,7 +115,6 @@ namespace ep
          * table.
          *
          * @param[in] r_div ResistorDivider instance to use when measuring the thermistor's resistance
-         * @param[in] r_fixed Fixed resistance in voltage divider sense circuit (ohms)
          * @param[in] map ValueMapping object that provides the resistance (ohms) to temperature (C) table
          * @param[in] ntc_is_pull_up (optional) True if the NTC is the pull-up resistor in the divider circuit
          *
@@ -120,14 +122,13 @@ namespace ep
          * ValueMapping object to pass in
          *
          */
-        ThermistorNTC(ResistorDivider& r_div, float r_fixed, ValueMapping *map, bool ntc_is_pull_up = true);
+        ThermistorNTC(ResistorDivider* r_div, ValueMapping* map, bool ntc_is_pull_up = true);
 
         /**
          * Constructor for temperature conversion using a direct calculation
          * from a beta value given in the thermistor's datasheet.
          *
          * @param[in] r_div ResistorDivider instance to use when measuring the thermistor's resistance
-         * @param[in] r_fixed Fixed resistance in voltage divider sense circuit (ohms)
          * @param[in] beta Beta value for thermistor given by device's datasheet
          * @param[in] r_room_temp Nominal resistance of NTC thermistor (ohms) @ room temperature (25C)
          * @param[in] ntc_is_pull_up (optional) True if the NTC is the pull-up resistor in the divider circuit
@@ -137,7 +138,7 @@ namespace ep
          * easier to implement
          *
          */
-        ThermistorNTC(ResistorDivider& r_div, float r_fixed, float beta, float r_room_temp, bool ntc_is_pull_up = true);
+        ThermistorNTC(ResistorDivider* r_div, float beta, float r_room_temp, bool ntc_is_pull_up = true);
 
         virtual ~ThermistorNTC() { }
 
@@ -156,11 +157,10 @@ namespace ep
 
     protected:
 
-        ResistorDivider& r_div;     /** ResistorDivider used to measure the thermistor's resistance */
+        ResistorDivider* r_div;     /** ResistorDivider used to measure the thermistor's resistance */
 
-        ValueMapping *r_to_t_map;   /** ValueMapping for resistance to temperature, if given */
+        ValueMapping* r_to_t_map;   /** ValueMapping for resistance to temperature, if given */
         float beta_val;             /** Beta value for thermistor given by datasheet, if given */
-        float r_fixed_ohms;         /** Fixed resistance in voltage divider sense circuit in ohms */
         float r_room_temp_ohms;     /** Nominal temperature of thermistor at room temp in ohms, if given */
 
         bool ntc_is_pull_up;        /** True if NTC is the pull-up in the divider circuit, false if pull-down */


### PR DESCRIPTION
Removed unneeded `r_fixed` parameter from ThermistorNTC API. This value was abstracted away when the NTC API was updated to use the ResistorDivider API.

Updated code examples to be compatible with Mbed-OS 6.

Changed constructors from using references to pointers so that subclass pointers can be passed into constructors and used transparently. References prevented this.

Resolves #21 
Resolves #22 