### PR TITLE
Created MovingAverageFilter implementation and unit tests

### DIFF
--- a/UNITTESTS/extensions/CallChain/README.md
+++ b/UNITTESTS/extensions/CallChain/README.md
@@ -1,0 +1,1 @@
+Could not get this to compile as of 2/9/21.

--- a/UNITTESTS/extensions/CallChain/disabled-unittest
+++ b/UNITTESTS/extensions/CallChain/disabled-unittest
@@ -7,12 +7,12 @@ set(unittest-includes ${unittest-includes}
   .
   ../
   ../../mbed-os/
-  ../../mbed-os/platform/
+  ../../mbed-os/platform/cxxsupport/
+  ../../mbed-os/platform/include/
   ../platform/
 )
 
 set(unittest-sources
-  ../../mbed-os/UNITTESTS/stubs/mbed_assert_stub.cpp
 )
 
 set(unittest-test-sources

--- a/UNITTESTS/extensions/dsp/MovingAverageFilter/test_MovingAverageFilter.cpp
+++ b/UNITTESTS/extensions/dsp/MovingAverageFilter/test_MovingAverageFilter.cpp
@@ -1,0 +1,88 @@
+/**
+ * ep-oc-mcu
+ * Embedded Planet Open Core for Microcontrollers
+ *
+ * Built with ARM Mbed-OS
+ *
+ * Copyright (c) 2019 Embedded Planet, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include "extensions/dsp/MovingAverageFilter.h"
+
+#include <string>
+
+float input_data[9] = { 2.0f, 4.0f, 6.0f, 8.0f, 12.0f, 14.0f, 16.0f, 18.0f, 20.0f };
+
+/**
+ * Test the MovingAverageFilter
+ */
+class TestMovingAverageFilter : public testing::Test {
+
+	virtual void SetUp()
+    {
+    }
+
+    virtual void TearDown()
+    {
+    }
+};
+
+
+/**
+ * Test MovingAverageFilter with single initial value
+ */
+TEST_F(TestMovingAverageFilter, single_iv)
+{
+    MovingAverageFilter<float, 2> filter(2);
+    EXPECT_FLOAT_EQ(filter.push(4), 3.0f);
+    EXPECT_FLOAT_EQ(filter.push(4), 4.0f);
+    EXPECT_FLOAT_EQ(filter.push(2), 3.0f);
+    EXPECT_FLOAT_EQ(filter.push(0), 1.0f);
+}
+
+/**
+ * Test MovingAverageFilter with multiple initial values
+ */
+TEST_F(TestMovingAverageFilter, multiple_iv)
+{
+    MovingAverageFilter<float, 4> filter(mbed::make_const_Span<4, float>(input_data));
+    EXPECT_FLOAT_EQ(filter.get_running_average(), 5.0f);
+    EXPECT_FLOAT_EQ(filter.push(input_data[4]), 7.5f);
+    EXPECT_FLOAT_EQ(filter.push(input_data[5]), 10.0f);
+    EXPECT_FLOAT_EQ(filter.push(input_data[6]), 12.5f);
+    EXPECT_FLOAT_EQ(filter.push(input_data[7]), 15.0f);
+    EXPECT_FLOAT_EQ(filter.push(input_data[8]), 17.0f);
+}
+
+/**
+ * Test MovingAverageFilter with array input push values
+ */
+TEST_F(TestMovingAverageFilter, push_multiple)
+{
+    float output_data[5];
+    float expected[5] = { 7.5f, 10.0f, 12.5f, 15.0f, 17.0f };
+    MovingAverageFilter<float, 4> filter(mbed::make_const_Span<4, float>(input_data));
+    EXPECT_FLOAT_EQ(filter.get_running_average(), 5.0f);
+    filter.push(mbed::make_const_Span<5, float>(&input_data[4]),
+            mbed::make_Span<float, 5>(output_data));
+    for(int i = 0; i < 5; i++) {
+        EXPECT_FLOAT_EQ(expected[i], output_data[i]);
+    }
+}
+
+

--- a/UNITTESTS/extensions/dsp/MovingAverageFilter/unittest.cmake
+++ b/UNITTESTS/extensions/dsp/MovingAverageFilter/unittest.cmake
@@ -1,0 +1,24 @@
+
+####################
+# UNIT TESTS
+####################
+
+set(unittest-includes ${unittest-includes}
+  .
+  ../
+  ../../mbed-os/
+  ../../mbed-os/platform/include/
+  ../platform/
+)
+
+set(unittest-sources
+  ../../mbed-os/UNITTESTS/stubs/mbed_assert_stub.cpp
+)
+
+set(unittest-test-sources
+  extensions/dsp/MovingAverageFilter/test_MovingAverageFilter.cpp
+)
+
+set(CONF_FLAGS "-DMBED_CONF_PLATFORM_CTHUNK_COUNT_MAX=10")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${DEVICE_FLAGS} ${CONF_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${DEVICE_FLAGS} ${CONF_FLAGS}")

--- a/extensions/dsp/MovingAverageFilter.h
+++ b/extensions/dsp/MovingAverageFilter.h
@@ -1,0 +1,102 @@
+/**
+ * ep-oc-mcu
+ * Embedded Planet Open Core for Microcontrollers
+ *
+ * Built with ARM Mbed-OS
+ *
+ * Copyright (c) 2019-2021 Embedded Planet, Inc.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef EP_OC_MCU_EXTENSIONS_DSP_MOVINGAVERAGEFILTER_H_
+#define EP_OC_MCU_EXTENSIONS_DSP_MOVINGAVERAGEFILTER_H_
+
+#include <assert.h>
+
+#include "platform/Span.h"
+
+template<typename T, unsigned int Size>
+class MovingAverageFilter
+{
+
+public:
+
+    MovingAverageFilter(T initial_value) : _index(0) {
+        _running_avg = initial_value;
+        for(int i = 0; i < Size; i++) {
+            _state[i] = initial_value/Size;
+        }
+    }
+
+    MovingAverageFilter(mbed::Span<const T, Size> initial_values) : _index(0) {
+        for(int i = 0; i < Size; i++) {
+            _state[i] = initial_values[i]/Size;
+            _running_avg += _state[i];
+        }
+    }
+
+    /**
+     * Push a single value into the MovingAverageFilter.
+     * @param[in] val Value to average into the filter
+     * @retval Updated running average
+     */
+    T push(T val) {
+        _running_avg -= _state[_index];
+        _state[_index] = val/Size;
+        _running_avg += _state[_index];
+        _index++;
+        if(_index >= Size) {
+            _index = 0;
+        }
+        return _running_avg;
+    }
+
+    /**
+     * Push multiple values into the MovingAverageFilter, and get multiple
+     * output values.
+     *
+     * @param[in] input Input array of values
+     * @param[out] output Output array of values
+     *
+     * @note The output span must have a size equal to or larger than the input span
+     */
+    void push(mbed::Span<const T> input, mbed::Span<T> output) {
+
+        assert(output.size() >= input.size());
+
+        for(int i = 0; i < input.size(); i++) {
+            output[i] = push(input[i]);
+        }
+
+    }
+
+    T get_running_average() const {
+        return _running_avg;
+    }
+
+protected:
+
+    unsigned int _index;
+
+    T _state[Size];
+
+    T _running_avg;
+
+
+};
+
+
+
+#endif /* EP_OC_MCU_EXTENSIONS_DSP_MOVINGAVERAGEFILTER_H_ */


### PR DESCRIPTION
Created a templatized MovingAverageFilter implementation. It is for simpler applications that do not require high speed performance, though it may still be fast enough for real time applications in some cases.

The unit tests show examples of how to use this API.

Complex classes can be averaged using this filter by defining the appropriate operators. For example, a 3-axis accelerometer reading could be averaged with one `MovingAverageFilter<3AxisReading>` instance if addition, subtraction, and division operators are defined for those datatypes.