### PR TITLE
Update PersistentVariable

### DIFF
--- a/TESTS/extensions/persistent-variable/main.cpp
+++ b/TESTS/extensions/persistent-variable/main.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2013-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdio.h>
+#include <string.h>
+#include "greentea-client/test_env.h"
+#include "unity/unity.h"
+#include "utest/utest.h"
+#include "kvstore_global_api/kvstore_global_api.h"
+
+#include "PersistentVariable.h"
+
+#include "drivers/Timeout.h"
+
+/**
+ * Note: This test is mostly to ensure API calls are valid and build/operate properly
+ * in common use cases. It does NOT test the persistence of the data itself
+ */
+
+using namespace utest::v1;
+using namespace ep;
+
+void test_case_primitive_types()
+{
+    static PersistentVariable<uint8_t> test_uint8(1, "test_uint8_t");
+    TEST_ASSERT_EQUAL(2, test_uint8 + 1);
+    test_uint8 = 3;
+    TEST_ASSERT_EQUAL(4, test_uint8 + 1);
+
+    PersistentVariable<float> test_float(2.0f, "test_float");
+    TEST_ASSERT_EQUAL_FLOAT(3.5f, test_float + 1.5f);
+    test_float = 3.25f;
+    TEST_ASSERT_EQUAL_FLOAT(4.50f, test_float + 1.25f);
+}
+
+struct test_struct_t {
+    uint8_t test_uint8 = 1;
+    float test_float = 2.15f;
+    int16_t test_int16 = -1204;
+    char name[8];
+
+    test_struct_t() {
+        strcpy(name, "hello");
+    }
+};
+
+void test_case_struct_types()
+{
+    static PersistentVariable<test_struct_t> test_struct(test_struct_t(),
+            "test_struct");
+
+    TEST_ASSERT_EQUAL(test_struct.get().test_uint8, 1);
+    TEST_ASSERT_EQUAL_FLOAT(test_struct.get().test_float, 2.15f);
+    TEST_ASSERT_EQUAL(test_struct.get().test_int16, -1204);
+    TEST_ASSERT_EQUAL_STRING(test_struct.get().name, "hello");
+
+    test_struct_t modified;
+    modified.test_uint8 = 2;
+    modified.test_float = 2.2f;
+    modified.test_int16 = -1222;
+    strcpy(modified.name, "world");
+
+    test_struct.set(modified);
+
+    TEST_ASSERT_EQUAL(test_struct.get().test_uint8, 2);
+    TEST_ASSERT_EQUAL_FLOAT(test_struct.get().test_float, 2.2f);
+    TEST_ASSERT_EQUAL(test_struct.get().test_int16, -1222);
+    TEST_ASSERT_EQUAL_STRING(test_struct.get().name, "world");
+
+}
+
+void test_case_array_types()
+{
+
+    uint8_t initial[7]= {0, 1, 2, 3, 4, 5, 6};
+    uint8_t updated[7] = { 0 };
+    PersistentArray<uint8_t, 7> test_array(mbed::make_Span(initial), "test_array");
+
+    for(int i = 0; i < 7; i++ ) {
+        updated[i] = test_array.get()[i] + 1;
+    }
+
+    test_array.set(mbed::make_Span(updated));
+    for(int i = 0; i < 7; i++) {
+        TEST_ASSERT_EQUAL(updated[i], test_array.get()[i]);
+    }
+
+}
+
+void test_case_string_types()
+{
+// TODO
+}
+
+
+static PersistentVariable<uint8_t> test_irq(1, "test_irq");
+static volatile uint8_t interrupt_val;
+static volatile bool interrupt_done = false;
+mbed::Timeout _timeout;
+
+void test_case_interrupt_handler() {
+    interrupt_val = test_irq;
+    interrupt_done = true;
+}
+
+void test_case_interrupt() {
+
+    interrupt_val = 0;
+    _timeout.attach_us(test_case_interrupt_handler, 10000);
+    while(!interrupt_done) {
+
+    }
+
+    TEST_ASSERT_EQUAL(interrupt_val, test_irq);
+
+}
+
+utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason)
+{
+    greentea_case_failure_abort_handler(source, reason);
+    return STATUS_CONTINUE;
+}
+
+// Generic test cases
+Case cases[] = {
+    Case("primitive types", test_case_primitive_types, greentea_failure_handler),
+    Case("struct types", test_case_struct_types, greentea_failure_handler),
+    Case("array types", test_case_array_types, greentea_failure_handler),
+    Case("string types", test_case_string_types, greentea_failure_handler),
+    Case("irq test", test_case_interrupt, greentea_failure_handler)
+};
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(20, "default_auto");
+
+    /** Format KVStore */
+    int err = kv_reset(KV_STORE_DEFAULT_PARTITION_NAME(MBED_CONF_STORAGE_DEFAULT_KV));
+    TEST_ASSERT_EQUAL_ERROR_CODE(MBED_SUCCESS, err);
+
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+
+int main()
+{
+    Harness::run(specification);
+}

--- a/extensions/PersistentArray.h
+++ b/extensions/PersistentArray.h
@@ -1,0 +1,162 @@
+/*
+ * Mbed-OS Microcontroller Library
+ * Copyright (c) 2021 Embedded Planet
+ * Copyright (c) 2021 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#ifndef EP_OC_MCU_EXTENSIONS_PERSISTENTARRAY_H_
+#define EP_OC_MCU_EXTENSIONS_PERSISTENTARRAY_H_
+
+#include "kvstore_global_api.h"
+#include "platform/mbed_error.h"
+#include "platform/mbed_assert.h"
+#include "platform/Span.h"
+#include "platform/mbed_critical.h"
+#include "mbed-trace/mbed_trace.h"
+
+#include <cstring>
+
+#include <stdio.h>
+
+namespace ep {
+
+/**
+ * Templatized Persistent Array built on top of Mbed's
+ * KVStore API. If KVStore is not available the API will fall back to
+ * non-volatile storage with a default initialized
+ */
+template<typename T, ptrdiff_t N>
+class PersistentArray
+{
+public:
+
+    /**
+     * Initialize a persistent array with a default array of values
+     * @param[in] default_array Array of default values to use
+     * @param[in] key Key to use for kvstore
+     *
+     * @note This value is only used if the persistent variable has not
+     * been accessed before or if the kvstore is unavailable for some reason
+     */
+    PersistentArray(mbed::Span<T,N> default_array, const char *key, uint32_t flags = 0) : _key(key), _flags(flags) {
+        memcpy(_array, default_array.data(), N*sizeof(T));
+    }
+
+    /**
+     * Initialize a persistent array with a default value
+     * @param[in] default_value The default value of the array. Every array element will be set to this value.
+     * @param[in] key Key to use for kvstore
+     *
+     * @note This value is only used if the persistent variable has not
+     * been accessed before or if the kvstore is unavailable for some reason
+     */
+    PersistentArray(T default_value, const char *key, uint32_t flags = 0) : _key(key), _flags(flags) {
+        memset(_array, default_value, N*sizeof(T));
+    }
+
+    /** Destructor */
+    ~PersistentArray(void) {
+    }
+
+    /**
+     * Attempts to get the underlying value from KVStore
+     * @retval value Value obtained from KVStore of default if unavailable
+     * @note Interrupt safe. A cached value will be returned if called from an interrupt.
+     */
+    mbed::Span<T,N> get(void)   {
+
+        /* If we're in an ISR, just return the cached value */
+        if(!core_util_is_isr_active()) {
+
+            // Try to access the KVStore partition
+            size_t actual_size;
+            int err = kv_get(_key, _array, N*sizeof(T), &actual_size);
+
+            /** If we weren't able to get the variable,
+                attempt to set the default value in KVStore */
+            if(err == MBED_ERROR_ITEM_NOT_FOUND) {
+
+                mbed_tracef(TRACE_LEVEL_WARN, "PARR", "item \"%s\" not found in kvstore, attempting to set...", _key);
+
+                this->set(mbed::make_Span(_array));
+
+                // Now try to get the key... if this doesn't work we will return default
+                err = kv_get(_key, _array, N*sizeof(T), &actual_size);
+            }
+
+            if(err) {
+                mbed_tracef(TRACE_LEVEL_WARN, "PARR", "could not get item \"%s\" from kvstore: %d", _key, err);
+            }
+
+            if(actual_size != N*sizeof(T)) {
+                mbed_tracef(TRACE_LEVEL_WARN, "PARR", "actual size (%u) of kvstore entry did not match expected size (%u)", actual_size, N*sizeof(T));
+            }
+        }
+
+        return mbed::make_Span(_array);
+    }
+
+    /**
+     * Attempts to set the underlying value in KVStore
+     * @param[in] value Value to set
+     *
+     * @note Not interrupt safe
+     */
+    void set(mbed::Span<T,N> new_value)  {
+
+        memcpy(_array, new_value.data(), new_value.size()*sizeof(T));
+
+        /**
+         * Try to access the KVStore partition
+         * If this doesn't work value stays default
+         */
+        int err = kv_set(_key, _array, N*sizeof(T), _flags);
+
+        if(err) {
+            mbed_tracef(TRACE_LEVEL_WARN, "PARR", "could not set entry \"%s\": %d", _key, err);
+        }
+    }
+
+    /**
+     * Checks if the given PersistentVariable already exists in KVStore
+     * @return true if exists, false if not
+     * @note Not interrupt safe
+     */
+    bool exists()  {
+        /* This API cannot be called from an ISR, assert here if so
+         * Otherwise it will assert later on and be harder to find. */
+        assert(!core_util_is_isr_active());
+        size_t actual_size;
+        int err = kv_get(_key, _array, sizeof(T), &actual_size);
+        if(err) {
+            // TODO this can also return false if a different error occurs other than "doesn't exist"
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+protected:
+
+    T _array[N];
+    const char *_key;
+
+    uint32_t _flags;
+};
+
+}
+
+#endif /* EP_OC_MCU_EXTENSIONS_PERSISTENTARRAY_H_ */

--- a/extensions/PersistentVariable.h
+++ b/extensions/PersistentVariable.h
@@ -21,338 +21,77 @@
  *
  */
 
-/**
- * TODO - make it possible to specify an alternate KVstore partition in the constructor (w/ default parameter)
- *
- */
-
 #ifndef EP_OC_MCU_EXTENSIONS_PERSISTENTVARIABLE_H_
 #define EP_OC_MCU_EXTENSIONS_PERSISTENTVARIABLE_H_
 
-#include "kvstore_global_api.h"
-#include "platform/mbed_error.h"
-#include "platform/mbed_assert.h"
-#include "platform/Span.h"
-#include "platform/mbed_critical.h"
+#include "PersistentArray.h"
 
-#include <cstring>
-
-#include <stdio.h>
-
-/** Macro fun :) */
-#define FORMAT_PARTITION_NAME(s) "/" #s "/"
-#define KV_STORE_DEFAULT_PARTITION_NAME(s) FORMAT_PARTITION_NAME(s)
-
-#ifndef COMPONENT_FLASHIAP
-#warning PersistentVariable - Persistence will be unavailable unless COMPONENT_FLASHIAP is enabled
-#endif
+// TODO think about checking if the value is the same during ::set to prevent unnecessary writes to flash
 
 namespace ep
 {
 
-	/**
-	 * Templatized persistent variable built on top of mbed's
-	 * KVStore API. If KVStore is not available (ie: COMPONENT_FLASHIAP is disabled)
-	 * the API will fall back to non-volatile storage with a default initialized
-	 */
-	template<typename T>
-	class PersistentVariable
-	{
-
-	public:
-
-		/** Initialize a persistent variable with a default value
-		 * @param[in] default_value The default value of this persistent variable
-		 *
-		 * @note This value is only used if the persistent variable has not
-		 * been accessed before or if the kvstore is unavailable for some reason
-		 */
-		PersistentVariable(T default_value, const char* key) : _value(default_value) {
-
-#ifdef COMPONENT_FLASHIAP
-
-
-			// Default partition name length (configured with json, defaults to '/kv/'
-			size_t default_partition_len = strlen(KV_STORE_DEFAULT_PARTITION_NAME(MBED_CONF_STORAGE_DEFAULT_KV));
-
-			// Format the given key to comply with KVStore requirements
-			_key = new char[(strlen(key)-1)+default_partition_len];
-			strcpy(_key, KV_STORE_DEFAULT_PARTITION_NAME(MBED_CONF_STORAGE_DEFAULT_KV));
-			strcpy(&_key[default_partition_len], &key[1]); // skip over the preceding '/'
-
-			// Get the index of the slash between module and variable name
-			char* slash = strrchr(_key, '/');
-
-			// Replace it with a dash ('-') to comply with mbed's KVStore requirements
-			*slash = '-';
-
-#endif
-		}
-
-		/** Destructor */
-		~PersistentVariable(void) {
-
-#ifdef COMPONENT_FLASHIAP
-
-			if(_key) {
-				delete[] _key;
-				_key = NULL;
-			}
-#endif
-		}
-
-
-
-		/**
-		 * Assignment operator for updating the value stored in persistent
-		 * memory (if available)
-		 */
-		T &operator= (const T &rhs) {
-			this->set(rhs);
-			return _value;
-		}
-
-		/** Evaluation operator
-		 *
-		 * Reads underlying persistent memory and returns current value (or default)
-		 */
-		operator T() {
-			this->get();
-			return _value;
-		}
-
-		/**
-		 * Attempts to get the underlying value from KVStore
-		 * @retval value Value obtained from KVStore of default if unavailable
-		 * @note Interrupt safe. A cached value will be returned if called from an interrupt.
-		 */
-		T get(void) {
-
-		    /* If we're in an ISR, just return the cached value */
-		    if(!core_util_is_isr_active()) {
-
-#ifdef COMPONENT_FLASHIAP
-                // Try to access the KVStore partition
-                size_t actual_size;
-                int err = kv_get(_key, &_value, sizeof(T), &actual_size);
-
-                /** If we weren't able to get the variable,
-                    attempt to set the default value in KVStore */
-                if(err == MBED_ERROR_ITEM_NOT_FOUND) {
-
-                    this->set(_value);
-
-                    // Now try to get the key... if this doesn't work we will return default
-                    kv_get(_key, &_value, sizeof(T), &actual_size);
-                }
-#endif
-		    }
-
-			return _value;
-		}
-
-		/** Attempts to set the underlying value in KVStore
-		 * @param[in] value Value to set
-		 *
-		 * @note Not interrupt safe
-		 */
-		void set(T new_value) {
-
-			_value = new_value;
-
-#ifdef COMPONENT_FLASHIAP
-
-			// Try to access the KVStore partition
-			int err = kv_set(_key, &_value, sizeof(T), 0);
-
-			/** If we weren't able to set the variable,
-				attempt to initialize the partition */
-			if(err != MBED_SUCCESS) {
-
-				// Return the last cached value (most likely default) if this fails
-				if(init_kvstore_partition() != MBED_SUCCESS) {
-					return;
-				} else {
-					// Now try to set the key... if this doesn't work value stays default
-					kv_set(_key, &_value, sizeof(T), 0);
-				}
-			}
-#endif
-
-		}
-
-		/*
-		 * Attempts to initialize the KVStore partition
-		 *
-		 * @retval err kv store error
-		 */
-		int init_kvstore_partition(void) {
-#ifdef COMPONENT_FLASHIAP
-
-			// Reset the partition with the default name
-			return kv_reset(KV_STORE_DEFAULT_PARTITION_NAME(MBED_CONF_STORAGE_DEFAULT_KV));
-#endif
-		}
-
-	protected:
-
-		T _value;
-		char* _key;
-
-	};
-
-	/**
-	 * Persistent Array
-	 * TODO: somehow combine PersistentVariable and PersistentArray using C++ magic
-	 */
-	template<typename T, size_t N>
-	class PersistentArray
-	{
-	public:
-
-	    /**
-	     * Initialize a persistent array with a default array of values
-	     * @param[in] default_array Array of default values to use
-	     * @param[in] key Key to use for kvstore
-	     *
-	     * @note This value is only used if the persistent variable has not
-         * been accessed before or if the kvstore is unavailable for some reason
-	     */
-	    PersistentArray(mbed::Span<T,N> default_array, const char *key) {
-	        memcpy(_array, default_array.data(), N);
-	        init_key(key);
-	    }
-
-	    /**
-         * Initialize a persistent array with a default value
-         * @param[in] default_value The default value of the array. Every array element will be set to this value.
-         * @param[in] key Key to use for kvstore
-         *
-         * @note This value is only used if the persistent variable has not
-         * been accessed before or if the kvstore is unavailable for some reason
-         */
-	    PersistentArray(T default_value, const char *key) {
-	        memset(_array, default_value, N);
-	        init_key(key);
-        }
-
-        /** Destructor */
-        ~PersistentArray(void) {
-
-#ifdef COMPONENT_FLASHIAP
-
-            if(_key) {
-                delete[] _key;
-                _key = NULL;
-            }
-#endif
-        }
-
-        /** Attempts to get the underlying value from KVStore
-         * @retval value Value obtained from KVStore of default if unavailable
-         *
-         * @note Interrupt safe. A cached value will be returned if called from an interrupt.
-         */
-        mbed::Span<T,N> get(void) {
-
-            /* If we're in an ISR, just return the cached value */
-            if(!core_util_is_isr_active()) {
-#ifdef COMPONENT_FLASHIAP
-
-                // Try to access the KVStore partition
-                size_t actual_size;
-                int err = kv_get(_key, _array, N, &actual_size);
-
-                /** If we weren't able to get the variable,
-                    attempt to set the default value in KVStore */
-                if(err == MBED_ERROR_ITEM_NOT_FOUND) {
-
-                    this->set(mbed::make_Span(_array));
-
-                    // Now try to get the key... if this doesn't work we will return default
-                    kv_get(_key, _array, N, &actual_size);
-                }
-#endif
-            }
-
-            return mbed::make_Span(_array);
-        }
-
-        /** Attempts to set the underlying value in KVStore
-         * @param[in] value Value to set
-         * @note Not interrupt safe
-         */
-        void set(mbed::Span<T,N> new_value) {
-
-            memcpy(_array, new_value.data(), new_value.size());
-
-#ifdef COMPONENT_FLASHIAP
-
-            // Try to access the KVStore partition
-            int err = kv_set(_key, _array, N, 0);
-
-            /** If we weren't able to set the variable,
-                attempt to initialize the partition */
-            if(err != MBED_SUCCESS) {
-
-                // Return the last cached value (most likely default) if this fails
-                if(init_kvstore_partition() != MBED_SUCCESS) {
-                    return;
-                } else {
-                    // Now try to set the key... if this doesn't work value stays default
-                    kv_set(_key, _array, N, 0);
-                }
-            }
-#endif
-
-        }
-
-        /*
-         * Attempts to initialize the KVStore partition
-         *
-         * @retval err kv store error
-         */
-        int init_kvstore_partition(void) {
-#ifdef COMPONENT_FLASHIAP
-
-            // Reset the partition with the default name
-            return kv_reset(KV_STORE_DEFAULT_PARTITION_NAME(MBED_CONF_STORAGE_DEFAULT_KV));
-#endif
-        }
-
-        /**
-         * Sets up the key
-         */
-        void init_key(const char *key) {
-
-#ifdef COMPONENT_FLASHIAP
-
-
-            // Default partition name length (configured with json, defaults to '/kv/'
-            size_t default_partition_len = strlen(KV_STORE_DEFAULT_PARTITION_NAME(MBED_CONF_STORAGE_DEFAULT_KV));
-
-            // Format the given key to comply with KVStore requirements
-            _key = new char[(strlen(key)-1)+default_partition_len];
-            strcpy(_key, KV_STORE_DEFAULT_PARTITION_NAME(MBED_CONF_STORAGE_DEFAULT_KV));
-            strcpy(&_key[default_partition_len], &key[1]); // skip over the preceding '/'
-
-            // Get the index of the slash between module and variable name
-            char* slash = strrchr(_key, '/');
-
-            // Replace it with a dash ('-') to comply with mbed's KVStore requirements
-            *slash = '-';
-
-#endif
-
-        }
-
-	protected:
-
-	    T _array[N];
-	    char *_key;
-	};
+/**
+ * Special case of PersistentArray with only 1 value
+ * Adds assignment and evaluation operators
+ */
+template<typename T>
+class PersistentVariable : public PersistentArray<T, 1>
+{
+
+public:
+
+    /** Initialize a persistent variable with a default value
+     * @param[in] default_value The default value of this persistent variable
+     * @param[in] key Key to store the persistent variable under
+     * @param[in] flags Creation flags for kvstore API (eg: WRITE_ONCE_FLAG)
+     *
+     * @note This value is only used if the persistent variable has not
+     * been accessed before or if the kvstore is unavailable for some reason
+     */
+    PersistentVariable(T default_value, const char* key, uint32_t flags = 0) :
+        PersistentArray<T, 1>(default_value, key, flags) {
+    }
+
+    /** Destructor */
+    ~PersistentVariable(void) {
+    }
+
+    /**
+     * Assignment operator for updating the value stored in persistent
+     * memory (if available)
+     */
+    T &operator= (const T &rhs) {
+        this->set(rhs);
+        return *this->_array;
+    }
+
+    /** Evaluation operator
+     *
+     * Reads underlying persistent memory and returns current value (or default)
+     */
+    operator T() {
+        this->get();
+        return *this->_array;
+    }
+
+    /**
+     * Alias for PersistentArray::get that returns a simple type
+     */
+    T get() {
+        PersistentArray<T, 1>::get();
+        return *this->_array;
+    }
+
+    /**
+     * Alias for PersistentArray::set that accepts a simple type
+     */
+    void set(T val) {
+        PersistentArray<T, 1>::set(mbed::make_Span<1, T>(&val));
+    }
+
+};
 
 }
-
 
 #endif /* EP_OC_MCU_EXTENSIONS_PERSISTENTVARIABLE_H_ */

--- a/extensions/TimeoutFlag.h
+++ b/extensions/TimeoutFlag.h
@@ -1,0 +1,79 @@
+/*
+ * Mbed-OS Microcontroller Library
+ * Copyright (c) 2021 Embedded Planet
+ * Copyright (c) 2021 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#ifndef EP_OC_MCU_EXTENSIONS_TIMEOUTFLAG_H_
+#define EP_OC_MCU_EXTENSIONS_TIMEOUTFLAG_H_
+
+#include "drivers/Timeout.h"
+#include "platform/Callback.h"
+
+#include <chrono>
+
+/* TODO extend this so that it supports both volatile bool and rtos flags. Use templating and create generic flag API + default implementations */
+
+/** Class encapsulating a flag that is set/reset by an IRQ timeout */
+class TimeoutFlag
+{
+public:
+
+    TimeoutFlag() {
+    }
+
+    /**
+     * Start the timeout. If the timeout expires before being reset, the internal
+     * flag will be set to true. Calling this before the timeout occurs resets the timeout with
+     * the new timeout duration
+     * @param[in] timeout Chrono duration of timeout
+     */
+    void start(std::chrono::microseconds timeout) {
+        _flag = false;
+        _timeout.detach();
+        _timeout.attach(mbed::callback(this, &TimeoutFlag::on_timeout), timeout);
+    }
+
+    /**
+     * Stop the timeout. The internal flag will be unchanged if the timeout has not yet occurred
+     */
+    void stop() {
+        _timeout.detach();
+    }
+
+    /**
+     * Returns true if the internal flag is set. ie: the timeout has occurred.
+     */
+    bool is_set() const {
+        return _flag;
+    }
+
+protected:
+
+    void on_timeout() {
+        _flag = true;
+    }
+
+protected:
+
+    volatile bool _flag = false;
+    mbed::Timeout _timeout;
+
+};
+
+
+
+#endif /* EP_OC_MCU_EXTENSIONS_TIMEOUTFLAG_H_ */


### PR DESCRIPTION
Admittedly not my cleanest work, but time is short.

This PR introduces `PersistentArray` and fixes runtime errors caused by accessing persistent variables from an interrupt (resolves #10).

Note that it is still not allowed to _set_ a persistent variable/array value from an interrupt, it can only be read.

One day I would like to merge the two classes with some C++ magic... but I have not studied enough to do this yet!

Also introduces some basic unit tests. They can be run by cloning ep-oc-mcu _next to_ mbed-os and running the following command from the base directory (change flags depending on your target/toolchain):

```
mbed test -t GCC_ARM -m NRF52840_DK -v -n ep-oc-mcu-tests-extensions-persistent-variable
```