### PR TITLE
Fix Gatt presentation format descriptors to report correct units and scaling on VL53L0X and Battery Voltage services.

### DIFF
--- a/features/FEATURE_BLE/services/BatteryVoltageService.h
+++ b/features/FEATURE_BLE/services/BatteryVoltageService.h
@@ -45,7 +45,7 @@ public:
 
 	BatteryVoltageService() :
 		battery_voltage_desc(GattCharacteristic::BLE_GATT_FORMAT_FLOAT32,
-				GattCharacteristic::BLE_GATT_UNIT_ELECTRIC_POTENTIAL_DIFFERENCE_VOLT), battery_voltage_desc_ptr(&battery_voltage_desc),
+				GattCharacteristic::BLE_GATT_UNIT_ELECTRIC_POTENTIAL_DIFFERENCE_VOLT, 0), battery_voltage_desc_ptr(&battery_voltage_desc),
 		battery_voltage_char(BATTERY_VOLTAGE_CHAR_UUID, &voltage,
 				GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_INDICATE | GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_NOTIFY,
 				(GattAttribute**)(&battery_voltage_desc_ptr), 1),

--- a/features/FEATURE_BLE/services/VL53L0XService.h
+++ b/features/FEATURE_BLE/services/VL53L0XService.h
@@ -45,7 +45,7 @@ public:
 
 	VL53L0XService() :
 		distance_desc(GattCharacteristic::BLE_GATT_FORMAT_UINT16,
-				GattCharacteristic::BLE_GATT_UNIT_ACCELERATION_METRES_PER_SECOND_SQUARED), distance_desc_ptr(&distance_desc),
+				GattCharacteristic::BLE_GATT_UNIT_LENGTH_METRE, -3), distance_desc_ptr(&distance_desc),
 		distance_char(VL53L0X_DISTANCE_CHAR_UUID, &distance,
 				GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_INDICATE | GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_NOTIFY,
 				(GattAttribute**)(&distance_desc_ptr), 1),


### PR DESCRIPTION
The current unit descriptors cause descriptor-aware applications to interpret the reported values as the incorrect physical unit and quantity:

The current VL53L0X descriptor indicates that the quantity is acceleration, with 1 count = 10 m/s<sup>2</sup>. This corrects it so the quantity is length, with 1 count = 0.001 meter, to match the units that that sensor reports.

The current battery voltage descriptor indicates 1.0 count = 10.0 volts. This corrects it to match usage so 1.0 count = 1.0 volt.

Note that this second issue in particular may also be present in the other sensor services, specifically, reporting 10 times the expected value over BLE due to the default `exponent` parameter in the `GattPresentationFormatDescriptor` being 1 (i.e. 1 count = 10 units) rather than 0 (1 count = 1 unit). I haven't gone through and checked the other sensors at all, and that change is not in this PR, but it may be worth looking at.